### PR TITLE
Remove all references to devcon3

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ The game acts both as a tool for those interested in learning ethereum, and as a
 You can find the current, official version at:
 [ethernaut.zeppelin.solutions](https://ethernaut.zeppelin.solutions)
 
-You can find the DEVCON3 version (ctf contest) at:
-[ethernaut-devcon3.zeppelin.solutions](https://ethernaut-devcon3.zeppelin.solutions)
-
 ### Running locally (development)
 
 1. Install

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -43,7 +43,6 @@ class Home extends React.Component {
           </h2>
           {/* INFO */}
           <p>The ethernaut is a Web3/Solidity based wargame inspired on <a href="https://overthewire.org" target="_blank" rel="noopener noreferred">overthewire.org</a> and the <a href="https://en.wikipedia.org/wiki/The_Eternaut" target="_blank" rel="noopener noreferred">El Eternauta</a> comic, played in the Ethereum Virtual Machine. Each level is a smart contract that needs to be 'hacked' in order to advance.</p>
-          <p>If you are looking for the CTF version released for Devcon3, please visit <a href="https://ethernaut-devcon3.zeppelin.solutions" target="_blank" rel="noopener noreferred">ethernaut-devcon3.zeppelin.solutions</a>. This version will be maintained for some time and is still 100% playable.</p>
           <p>Are you interested in smart contract development or security? Does securing the world’s blockchain infrastructure sound exciting to you? <a href="https://zeppelin.solutions/jobs" target="_blank" rel="noopener noreferred"><strong style={{ color: '#eb5424', fontWeight: 600 }}>We are hiring!</strong></a></p>
           <button
             style={{marginTop: '10px'}}


### PR DESCRIPTION
As `ethernaut-devcon3.zeppelin.solutions` is now no longer mantained, we're just not mentioning it here anymore.