### PR TITLE
[WIP] Web3 refactor to new injection

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -20,6 +20,9 @@ export const NETWORKS = {
   }
 }
 
+// Web3
+export const Web3 = require("web3")
+
 // Misc
 export const CLEAR_CONSOLE = !DEBUG
 export const GOOGLE_ANALYTICS_ID = 'UA-85043059-4'

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,20 @@ ReactDOM.render(
 );
 
 // Post-load actions.
-window.addEventListener('load', function() {
+window.addEventListener('load', async() => {
+
+  if (window.ethereum) {
+    window.web3 = new constants.Web3(window.ethereum)
+    try {
+      await window.ethereum.enable({mockRejection:true})
+    } catch (error) {
+      console.error(error)
+      window.web3 = null
+    }
+  } else if(window.web3) {
+    window.web3 = new constants.Web3(window.web3.currentProvider)
+  }
+
   if(window.web3) {
 
     ethutil.setWeb3(window.web3)

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,7 @@ window.addEventListener('load', async() => {
       await window.ethereum.enable()
     } catch (error) {
       console.error(error)
+      console.error(`Refresh the page to approve/reject again`)
       window.web3 = null
     }
   } else if(window.web3) {
@@ -99,6 +100,7 @@ function checkWrongNetwork(id) {
 
   if(onWrongNetwork) {
     console.error(`Heads up, you're on the wrong network!! @bad Please switch to the << ${constants.ACTIVE_NETWORK.name.toUpperCase()} >> network.`)
+    console.error(`1) From November 2 you can turn on privacy mode (off by default) in settings if you don't want to expose your info by default. 2) If privacy mode is turn on you have to authorized metamask to use this page. 3) then refresh.`)
   }
 
   return onWrongNetwork

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ window.addEventListener('load', async() => {
   if (window.ethereum) {
     window.web3 = new constants.Web3(window.ethereum)
     try {
-      await window.ethereum.enable({mockRejection:true})
+      await window.ethereum.enable()
     } catch (error) {
       console.error(error)
       window.web3 = null

--- a/src/middlewares/loadEthernautContract.js
+++ b/src/middlewares/loadEthernautContract.js
@@ -46,6 +46,6 @@ export default store => next => action => {
         store.dispatch(actions.loadLevelInstance(state.gamedata.activeLevel, true))
     })
     .catch(() => {
-      console.error(`@bad Ethernaut contract not found in the current network. Please make sure (1) that you are using metamask, (2) that it's on the ropsten testnet, (3) that it is unlocked, and (4) then refresh.`)
+      console.error(`@bad Ethernaut contract not found in the current network. Please make sure (1) that you are using metamask, (2) that it's on the ropsten testnet, (3) that it is unlocked, (4 optional) From November 2 you can turn ON privacy mode (OFF by default) in Metamask settings if you don't want to expose your info by default. (5 optional) If privacy mode is turn ON you have to authorized metamask to use this page. and (6) then refresh.`)
     })
 }

--- a/src/middlewares/setPlayerAddress.js
+++ b/src/middlewares/setPlayerAddress.js
@@ -12,7 +12,7 @@ export default store => next => action => {
   }
 
   if(!action.address) {
-    console.error(`@bad No player address detected! Make sure that 1) You've installed the metamask browser extension and 2) that it's unlocked.`)
+    console.error(`@bad No player address detected! Make sure that 1) You've installed the metamask browser extension and 2) that it's unlocked. 3 optional) From November 2 you can turn ON privacy mode (OFF by default) in settings if you don't want to expose your info by default. 4 optional) If privacy mode is turn ON you have to authorized metamask to use this page. 5) then refresh.`)
     return
   }
 


### PR DESCRIPTION
##### Description
<!-- A description on what this PR aims to solve -->
- This PR adds a code to prepare for Metamask changes that will happen from 2nd of November.
- The UI for Approve/Reject has not been implemented yet. Right now the account is enable by default.
- I have left in the code `mockRejection:true` as parameter in `window.ethereum.enable()` for testing the reject mode. Leave the field empty for normal approve mode.
- The code should work without problems after 2nd but it could be tested again when the UI for approve will be implemented in official version.
- I have also committed the fix for `NETWORKS.LOCAL`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Changes don't break existing behavior

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like Docs, UI, UX, Tests etc). -->
Web3


##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->
I have tested the code locally on Mac OS, using the latest version of Metamask (`4.12.0`)

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->
Fixes: #48 
