### PR TITLE
Updates view modifier advice

### DIFF
--- a/gamedata/descriptions/levels/elevator_complete.md
+++ b/gamedata/descriptions/levels/elevator_complete.md
@@ -1,4 +1,4 @@
-Currently, the Solidity compiler does nothing to enforce that a `view` or `constant` function is not modifying state. The same applies to `pure` functions, which should not read state but they can.
+You can use the `view` function modifier on an interface in order to prevent state modifications. The `pure` modifier also prevents functions from modifying the state.
 Make sure you read [Solidity's documentation](http://solidity.readthedocs.io/en/develop/contracts.html#view-functions) and learn its caveats.
 
 An alternative way to solve this level is to build a view function which returns different results depends on input data but don't modify state, e.g. `gasleft()`.


### PR DESCRIPTION
Issue #155.

Advice has been updated as view and pure functions will now prevent state modifications with the use of STATICCALL.