### PR TITLE
Fix event filtering when syncing player progress

### DIFF
--- a/src/middlewares/syncPlayerProgress.js
+++ b/src/middlewares/syncPlayerProgress.js
@@ -13,9 +13,9 @@ export default store => next => action => {
   ) return next(action)
 
   // Watch LevelCompletedLog
-  const log = state.contracts.ethernaut.LevelCompletedLog(
-    { player: state.player.address }
-  );
+  const log = state.contracts.ethernaut.LevelCompletedLog({
+    filter: { player: state.player.address }
+  });
 
   log.on('error', (error) => {
     if (error) {

--- a/test/EthernautTests.js
+++ b/test/EthernautTests.js
@@ -4,7 +4,7 @@ const DummyLevel = artifacts.require('./levels/DummyLevel.sol');
 const Dummy = artifacts.require('./levels/Dummy.sol');
 const FallbackFactory = artifacts.require('./levels/FallbackFactory.sol');
 const Manufactured = artifacts.require('./levels/Manufactured.sol');
-const { BN, constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers')
+const { expectRevert } = require('openzeppelin-test-helpers')
 import * as utils from './utils/TestUtils'
 
 contract('Ethernaut', function(accounts) {
@@ -31,7 +31,7 @@ contract('Ethernaut', function(accounts) {
     // const instance = await utils.createLevelInstance(ethernaut, level.address, player, Fallback)
     const instance = await Manufactured.new()
 
-    await expectRevert(ethernaut.submitLevelInstance(instance.address, {from: player}), 'VM Exception while processing transaction: revert')
+    await expectRevert.unspecified(ethernaut.submitLevelInstance(instance.address, {from: player}))
   });
 
   it(`should not allow player A to use player's B instance to complete a level`, async function() {
@@ -42,10 +42,9 @@ contract('Ethernaut', function(accounts) {
     const instance = await utils.createLevelInstance(ethernaut, level.address, player, Dummy)
     await instance.setCompleted(true);
     const completed = await instance.completed();
-    console.log(`completed:`, completed)
     assert.equal(completed, true)
 
-    await expectRevert(ethernaut.submitLevelInstance(instance.address, {from: accounts[2]}), 'VM Exception while processing transaction: revert')
+    await expectRevert.unspecified(ethernaut.submitLevelInstance(instance.address, {from: accounts[2]}))
   });
 
   it(`should not allow a player to generate 2 completion logs with the same instance`, async function() {
@@ -56,7 +55,6 @@ contract('Ethernaut', function(accounts) {
     const instance = await utils.createLevelInstance(ethernaut, level.address, player, Dummy)
     await instance.setCompleted(true);
     const completed = await instance.completed();
-    console.log(`completed:`, completed)
     assert.equal(completed, true)
 
     const ethCompleted = await utils.submitLevelInstance(
@@ -68,7 +66,7 @@ contract('Ethernaut', function(accounts) {
     assert.equal(ethCompleted, true)
 
     // Resubmit instance
-    await expectRevert(ethernaut.submitLevelInstance(instance.address), 'VM Exception while processing transaction: revert')
+    await expectRevert.unspecified(ethernaut.submitLevelInstance(instance.address))
   });
 
   it(`should provide instances and verify completion`, async function() {
@@ -79,7 +77,6 @@ contract('Ethernaut', function(accounts) {
     const instance = await utils.createLevelInstance(ethernaut, level.address, player, Dummy)
     await instance.setCompleted(true);
     const completed = await instance.completed();
-    console.log(`completed:`, completed)
     assert.equal(completed, true)
 
     const ethCompleted = await utils.submitLevelInstance(
@@ -109,11 +106,11 @@ contract('Ethernaut', function(accounts) {
 
   it(`should not provide instances to non-registered level factories`, async function() {
     const level = await DummyLevel.new()
-    await expectRevert(ethernaut.createLevelInstance(level.address, {from: player}), 'VM Exception while processing transaction: revert')
+    await expectRevert.unspecified(ethernaut.createLevelInstance(level.address, {from: player}))
   });
 
   it(`should not allow anyone but the owner to upload a level`, async function() {
     const level = await DummyLevel.new()
-    await expectRevert(ethernaut.registerLevel(level.address, {from: player}), 'VM Exception while processing transaction: revert')
+    await expectRevert.unspecified(ethernaut.registerLevel(level.address, {from: player}))
   });
 });

--- a/test/utils/TestUtils.js
+++ b/test/utils/TestUtils.js
@@ -48,9 +48,9 @@ export async function submitLevelInstance(ethernaut, levelAddress, instanceAddre
     const tx = await ethernaut.submitLevelInstance(instanceAddress, data);
     if(tx.logs.length === 0) resolve(false)
     else {
-      const log = tx.logs[0].args;
-      const ethLevelAddress = log.level;
-      const ethPlayer = log.player;
+      const events = tx.logs.filter(e => e.event === "LevelCompletedLog");
+      const ethLevelAddress = events[0].args.level;
+      const ethPlayer = events[0].args.player;
       if(player === ethPlayer && levelAddress === ethLevelAddress) {
         resolve(true)
       }


### PR DESCRIPTION
Hot fix for #160 

* Fixed filter on 'data' when syncing player progress

* Updated Ethernaut tests to:
   - Check for `LevelCompletedLog` event (in utils)
   - Remove 'VM Exception ...' message to improve test readability

I tested the new filter locally with a sample contract and a local Geth development node, to reproduce real conditions as close as possible, and the new filter should work as expected. This hot fix prevent further mismatches in completed levels when syncing player progress.