### PR TITLE
chore: updating for solidity > 0.5.0

### DIFF
--- a/gamedata/descriptions/levels/force_complete.md
+++ b/gamedata/descriptions/levels/force_complete.md
@@ -1,3 +1,3 @@
 In solidity, for a contract to be able to receive ether, the fallback function must be marked 'payable'.
 
-However, there is no way to stop an attacker from sending ether to a contract by self destroying. Hence, it is important not to count on the invariant `this.balance == 0` for any contract logic.
+However, there is no way to stop an attacker from sending ether to a contract by self destroying. Hence, it is important not to count on the invariant `address(this).balance == 0` for any contract logic.


### PR DESCRIPTION
See #209
`this.balance` is deprecated since Solidity 0.5.0 and replaced with `address(this).balance`
[From the Docs](https://docs.soliditylang.org/en/v0.8.3/units-and-global-variables.html#members-of-address-types)