### PR TITLE
Update hints for Gatekeeper 1

### DIFF
--- a/gamedata/descriptions/levels/gatekeeper1.md
+++ b/gamedata/descriptions/levels/gatekeeper1.md
@@ -2,4 +2,4 @@ Make it past the gatekeeper and register as an entrant to pass this level.
 
 ##### Things that might help:
 * Remember what you've learned from the Telephone and Token levels.
-* You can learn more about the `msg.gas` special variable, or its preferred alias `gasleft()`, in Solidity's documentation (see [here](http://solidity.readthedocs.io/en/v0.4.23/units-and-global-variables.html) and [here](http://solidity.readthedocs.io/en/v0.4.23/control-structures.html#external-function-calls)).
+* You can learn more about the special function `gasleft()`, in Solidity's documentation (see [here](https://docs.soliditylang.org/en/stable/units-and-global-variables.html) and [here](https://docs.soliditylang.org/en/stable/control-structures.html#external-function-calls)).

--- a/gamedata/descriptions/levels/gatekeeper1.md
+++ b/gamedata/descriptions/levels/gatekeeper1.md
@@ -2,4 +2,4 @@ Make it past the gatekeeper and register as an entrant to pass this level.
 
 ##### Things that might help:
 * Remember what you've learned from the Telephone and Token levels.
-* You can learn more about the special function `gasleft()`, in Solidity's documentation (see [here](https://docs.soliditylang.org/en/stable/units-and-global-variables.html) and [here](https://docs.soliditylang.org/en/stable/control-structures.html#external-function-calls)).
+* You can learn more about the special function `gasleft()`, in Solidity's documentation (see [here](https://docs.soliditylang.org/en/v0.8.3/units-and-global-variables.html) and [here](https://docs.soliditylang.org/en/v0.8.3/control-structures.html#external-function-calls)).


### PR DESCRIPTION
• `msg.gas` is deprecated since solidity 0.4.21
• the links to docs are being redirected to `soliditylang.org`
• updated docs version to `stable` (that might be controversial – please amend)