### PR TITLE
Adding SPDX licenses (MIT)

### DIFF
--- a/contracts/levels/AlienCodex.sol
+++ b/contracts/levels/AlienCodex.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.5.0;
 
 import '../helpers/Ownable-05.sol';

--- a/contracts/levels/CoinFlip.sol
+++ b/contracts/levels/CoinFlip.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 import '@openzeppelin/contracts/math/SafeMath.sol';

--- a/contracts/levels/Delegation.sol
+++ b/contracts/levels/Delegation.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 contract Delegate {

--- a/contracts/levels/Denial.sol
+++ b/contracts/levels/Denial.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 import '@openzeppelin/contracts/math/SafeMath.sol';

--- a/contracts/levels/Dex.sol
+++ b/contracts/levels/Dex.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/levels/Dummy.sol
+++ b/contracts/levels/Dummy.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 contract Dummy {

--- a/contracts/levels/DummyLevel.sol
+++ b/contracts/levels/DummyLevel.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 import './base/Level.sol';

--- a/contracts/levels/Elevator.sol
+++ b/contracts/levels/Elevator.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 

--- a/contracts/levels/Fallback.sol
+++ b/contracts/levels/Fallback.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 import '@openzeppelin/contracts/math/SafeMath.sol';

--- a/contracts/levels/Fallout.sol
+++ b/contracts/levels/Fallout.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 import '@openzeppelin/contracts/math/SafeMath.sol';

--- a/contracts/levels/Force.sol
+++ b/contracts/levels/Force.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 contract Force {/*

--- a/contracts/levels/GatekeeperOne.sol
+++ b/contracts/levels/GatekeeperOne.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 import '@openzeppelin/contracts/math/SafeMath.sol';

--- a/contracts/levels/GatekeeperTwo.sol
+++ b/contracts/levels/GatekeeperTwo.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 contract GatekeeperTwo {

--- a/contracts/levels/Instance.sol
+++ b/contracts/levels/Instance.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 contract Instance {

--- a/contracts/levels/King.sol
+++ b/contracts/levels/King.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 contract King {

--- a/contracts/levels/MagicNum.sol
+++ b/contracts/levels/MagicNum.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 contract MagicNum {

--- a/contracts/levels/NaughtCoin.sol
+++ b/contracts/levels/NaughtCoin.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 import '@openzeppelin/contracts/token/ERC20/ERC20.sol';

--- a/contracts/levels/Preservation.sol
+++ b/contracts/levels/Preservation.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 contract Preservation {

--- a/contracts/levels/Privacy.sol
+++ b/contracts/levels/Privacy.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 contract Privacy {

--- a/contracts/levels/Recovery.sol
+++ b/contracts/levels/Recovery.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 import '@openzeppelin/contracts/math/SafeMath.sol';

--- a/contracts/levels/RecoverySimpleToken.sol
+++ b/contracts/levels/RecoverySimpleToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 // This is used for the HiJack truffle test. 
 pragma solidity ^0.6.0;
 

--- a/contracts/levels/Reentrance.sol
+++ b/contracts/levels/Reentrance.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 import '@openzeppelin/contracts/math/SafeMath.sol';

--- a/contracts/levels/Shop.sol
+++ b/contracts/levels/Shop.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 interface Buyer {

--- a/contracts/levels/Telephone.sol
+++ b/contracts/levels/Telephone.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 contract Telephone {

--- a/contracts/levels/Token.sol
+++ b/contracts/levels/Token.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 contract Token {

--- a/contracts/levels/Vault.sol
+++ b/contracts/levels/Vault.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 contract Vault {


### PR DESCRIPTION
Remix pushes a warning on compilation every time SPDX is not present, so hopefully this will make debugging much more cleaner and pleasant for future people taking on the challenge

(original PR was [this](https://github.com/OpenZeppelin/ethernaut/pull/219), but messed up the whole rebase/merge and had to create a new PR)