### PR TITLE
puzzle_wallet.md: change hint to mention `msg.value`

### DIFF
--- a/client/src/gamedata/en/descriptions/levels/puzzle_wallet.md
+++ b/client/src/gamedata/en/descriptions/levels/puzzle_wallet.md
@@ -14,5 +14,5 @@ You'll need to hijack this wallet to become the admin of the proxy.
 
 &nbsp;
 Things that might help::
-* Understanding how `delegatecall`s work and how `msg.sender` behaves when performing one.
+* Understanding how `delegatecall`s work and how `msg.sender` and `msg.value` behaves when performing one.
 * Knowing about proxy patterns and the way they handle storage variables.

--- a/client/src/gamedata/ja/descriptions/levels/puzzle_wallet.md
+++ b/client/src/gamedata/ja/descriptions/levels/puzzle_wallet.md
@@ -14,5 +14,5 @@ You'll need to hijack this wallet to become the admin of the proxy.
 
 &nbsp;
 Things that might help::
-* Understanding how `delegatecall`s work and how `msg.sender` behaves when performing one.
+* Understanding how `delegatecall`s work and how `msg.sender` and `msg.value` behaves when performing one.
 * Knowing about proxy patterns and the way they handle storage variables.


### PR DESCRIPTION
Mentioning `msg.value` along with `msg.sender` since the solution does
require the former.
This points the reader on the right path while not giving too much away.