### PR TITLE
Fix explanation for pure modifier in Elevator

### DIFF
--- a/client/src/gamedata/en/descriptions/levels/elevator_complete.md
+++ b/client/src/gamedata/en/descriptions/levels/elevator_complete.md
@@ -1,4 +1,4 @@
-You can use the `view` function modifier on an interface in order to prevent state modifications. The `pure` modifier also prevents functions from modifying the state.
+You can use the `view` function modifier on an interface in order to prevent state modifications. The `pure` modifier also prevents functions from reading the state.
 Make sure you read [Solidity's documentation](http://solidity.readthedocs.io/en/develop/contracts.html#view-functions) and learn its caveats.
 
 An alternative way to solve this level is to build a view function which returns different results depends on input data but don't modify state, e.g. `gasleft()`.


### PR DESCRIPTION
In Solidity docs, the pure modifier explains to ensure for function calls don’t modify and read the state.

> Functions can be declared pure in which case they promise not to read from or modify the state.

https://docs.soliditylang.org/en/develop/contracts.html#pure-functions