### PR TITLE
Fix typos/fragment in completion page after King

### DIFF
--- a/client/src/gamedata/en/descriptions/levels/king_complete.md
+++ b/client/src/gamedata/en/descriptions/levels/king_complete.md
@@ -1,6 +1,3 @@
-Most of Ethernaut's levels try to expose (in an oversimpliefied form of course) something that actually happend. A real hack or a real bug.
+Most of Ethernaut's levels try to expose (in an oversimplified form of course) something that actually happened — a real hack or a real bug.
 
-In this case, see:
-[King of the Ether](https://www.kingoftheether.com/thrones/kingoftheether/index.html)
-and
-[King of the Ether Postmortem](http://www.kingoftheether.com/postmortem.html)
+In this case, see: [King of the Ether](https://www.kingoftheether.com/thrones/kingoftheether/index.html) and [King of the Ether Postmortem](http://www.kingoftheether.com/postmortem.html).


### PR DESCRIPTION
Fixed misspelling of "oversimplified" and "happened", combined sentence fragment with previous sentence, and removed unnecessary newlines.