### PR TITLE
Allow DoubleEntryPoint bot reset on same instance

### DIFF
--- a/contracts/contracts/levels/DoubleEntryPoint.sol
+++ b/contracts/contracts/levels/DoubleEntryPoint.sol
@@ -23,7 +23,6 @@ contract Forta is IForta {
   mapping(address => uint256) public botRaisedAlerts;
 
   function setDetectionBot(address detectionBotAddress) external override {
-      require(address(usersDetectionBots[msg.sender]) == address(0), "DetectionBot already set");
       usersDetectionBots[msg.sender] = IDetectionBot(detectionBotAddress);
   }
 


### PR DESCRIPTION
Raising this PR assuming that instance reuse-ability is a desired property for this level but once we set a detection bot we can not set another one with different logic. If we can not reset the detection bot then the submission will keep using old failed bot and will keep failing.