### PR TITLE
compile version error!

### DIFF
--- a/contracts/contracts/attacks/ReentranceAttack.sol
+++ b/contracts/contracts/attacks/ReentranceAttack.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.4;
+pragma solidity ^0.6.12;
 
 import '../levels/Reentrance.sol';
 

--- a/contracts/contracts/attacks/ReentranceAttack.sol
+++ b/contracts/contracts/attacks/ReentranceAttack.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity ^0.6.4;
 
 import '../levels/Reentrance.sol';
 

--- a/contracts/contracts/levels/Reentrance.sol
+++ b/contracts/contracts/levels/Reentrance.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.4;
+pragma solidity ^0.6.12;
 
 import '@openzeppelin/contracts/math/SafeMath.sol';
 

--- a/contracts/contracts/levels/Reentrance.sol
+++ b/contracts/contracts/levels/Reentrance.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.0;
+pragma solidity ^0.6.4;
 
 import '@openzeppelin/contracts/math/SafeMath.sol';
 


### PR DESCRIPTION
Solidity 0.6.4 and call{value: ...}() instead of call.value()()