### PR TITLE
Remove Level UI Scaling

### DIFF
--- a/client/src/containers/Level.js
+++ b/client/src/containers/Level.js
@@ -256,9 +256,11 @@ class Level extends React.Component {
           </section>
 
           <section className="descriptors">
-            <div className="boxes">
+            <div className="boxes author-section-border">
+              <div className="author-section">
               {/* AUTHOR */}
               {level.author && <Author author={level.author} />}
+            </div>
             </div>
           </section>
         </main>

--- a/client/src/styles/app.css
+++ b/client/src/styles/app.css
@@ -13,6 +13,10 @@
   --secondary-color: var(--black);
   margin-left: 15%;
   margin-right: 15%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }
 
 ::-webkit-scrollbar {
@@ -269,8 +273,7 @@ nav li {
 
 .source-code {
   margin-bottom: 2em;
-  max-width: 60%;
-  margin-left: 20%;
+  width: 800px;
 }
 
 .content_img div {
@@ -348,8 +351,8 @@ footer {
 .boxes {
   padding: 20px 20px 20px 20px;
   border: 2px solid var(--secondary-color);
-  width: 60%;
-  margin-left: 20%;
+  width: 800px;
+
   margin-bottom: 2em;
   text-align: left;
   border-radius: 6px;

--- a/client/src/styles/app.css
+++ b/client/src/styles/app.css
@@ -325,7 +325,20 @@ nav li {
   padding-left: 50px;
   padding-right: 50px;
 }
+.author-section-border{
+  border: none !important;
+}
+.author-section{
+  width: 60%;
+  margin-left: 20%;
 
+  padding: 20px 20px 20px 20px;
+  border: 2px solid var(--secondary-color);
+
+  margin-bottom: 2em;
+  text-align: left;
+  border-radius: 6px;
+}
 footer {
   width: 100vw;
   position: fixed;

--- a/client/src/styles/app.css
+++ b/client/src/styles/app.css
@@ -327,9 +327,9 @@ nav li {
 }
 
 footer {
-  width: 100%;
-  margin-left: -15%;
+  width: 100vw;
   position: fixed;
+  left: 0;
   padding: 10px 10px 0px 10px;
   bottom: 0;
   height: 25px;

--- a/client/src/styles/level.css
+++ b/client/src/styles/level.css
@@ -1,126 +1,125 @@
 /* Level selector */
 
-  
+
 .level-selector-nav {
-    margin-left: 20%;
-    width: 60%;
+  width: 800px;
 }
 
 .powered-by {
-    margin-left: auto;
-    margin-top: -2em;
-    margin-bottom: -2em;
-    margin-right: auto;
-    text-align: center;
+  margin-left: auto;
+  margin-top: -2em;
+  margin-bottom: -2em;
+  margin-right: auto;
+  text-align: center;
 }
 
 
 .dropdown-menu-bar {
-    display: flex;
-    justify-content: space-between;
-    align-items:center;
-    padding: 5px 30px;
-    margin-top: 1%;
-    overflow: hidden;
-    background-color: var(--primary-color);
-    border: solid var(--secondary-color) 2px;
-    border-radius: 6px;
-    font-style: none;
-    color: var(--secondary-color);
-    font-family: Arial, Helvetica, sans-serif;
-    font-weight: bolder;
-    font-size: larger;
-    text-decoration: none;
+  display: flex;
+  justify-content: space-between;
+  align-items:center;
+  padding: 5px 30px;
+  margin-top: 1%;
+  overflow: hidden;
+  background-color: var(--primary-color);
+  border: solid var(--secondary-color) 2px;
+  border-radius: 6px;
+  font-style: none;
+  color: var(--secondary-color);
+  font-family: Arial, Helvetica, sans-serif;
+  font-weight: bolder;
+  font-size: larger;
+  text-decoration: none;
 }
 
 .button-sequence {
-    margin-bottom: 2%;
-    text-align: center;
+  margin-bottom: 2%;
+  text-align: center;
 }
 
 .level-title {
-    margin-left: 43%;
+  margin-left: 43%;
 }
 
 .dropdown-menu-bar p{
-    height: 10px;
+  height: 10px;
 }
 
 .dropdown-menu-bar-button{
-    overflow: hidden;
+  overflow: hidden;
 }
 
 .level-selector-nav a{
-    font-style: none;
-    color: var(--secondary-color);
-    font-family: Arial, Helvetica, sans-serif;
-    font-weight: normal;
-    text-decoration: none;
+  font-style: none;
+  color: var(--secondary-color);
+  font-family: Arial, Helvetica, sans-serif;
+  font-weight: normal;
+  text-decoration: none;
 }
 
 .level-selector-dropdown-content{
-    display: none;
-    padding: 5px 5px;
-    margin-top: 1%;
-    overflow: hidden;
-    border: solid var(--secondary-color) 2px;
-    border-radius: 6px;
-    margin: 1% ;
-    font-style: none;
-    color: var(--primary-color);
-    font-family: Arial, Helvetica, sans-serif;
-    font-weight: normal;
-    text-decoration: none;
-    overflow-y: auto; 
-    height:400px;
+  display: none;
+  padding: 5px 5px;
+  margin-top: 1%;
+  overflow: hidden;
+  border: solid var(--secondary-color) 2px;
+  border-radius: 6px;
+  margin: 1% ;
+  font-style: none;
+  color: var(--primary-color);
+  font-family: Arial, Helvetica, sans-serif;
+  font-weight: normal;
+  text-decoration: none;
+  overflow-y: auto;
+  height:400px;
 }
 
 .level-selector-dropdown-content-item {
-    display: flex;
-    justify-content: space-between;
-    text-align:center;
-    width: auto;
-    background-color: var(--primary-color);
-    color: var(--secondary-color);
+  display: flex;
+  justify-content: space-between;
+  text-align:center;
+  width: auto;
+  background-color: var(--primary-color);
+  color: var(--secondary-color);
 }
 
 .level-selector-dropdown-content-item a{
-    background-color: var(--primary-color);
-    color: var(--secondary-color);
-    z-index: 1;
+  background-color: var(--primary-color);
+  color: var(--secondary-color);
+  z-index: 1;
 }
 
 .dropdown-button{
-    color: var(--secondary-color);
-    background-color:var(--primary-color);
+  color: var(--secondary-color);
+  background-color:var(--primary-color);
 }
 
 .level-selector-dropdown-content-item:hover {
-    background-color: var(--secondary-color);
-    color: var(--primary-color);
-    border: solid var(--secondary-color) 2px;
-    border-radius: 6px;
+  background-color: var(--secondary-color);
+  color: var(--primary-color);
+  border: solid var(--secondary-color) 2px;
+  border-radius: 6px;
 }
 
 .level-selector-dropdown-content-item:hover a{
-    background-color: var(--secondary-color);
-    color: var(--primary-color);
+  background-color: var(--secondary-color);
+  color: var(--primary-color);
 }
 
 .level-selector-nav:hover .level-selector-dropdown-content{
-    display: block;
-    /* position: absolute; */
-    z-index: 1;
-    background-color: var(--primary-color);
+  display: block;
+  /* position: absolute; */
+  z-index: 1;
+  background-color: var(--primary-color);
 }
 
 
 .level-img-view {
-    position: relative;
-    width: 60%;
-    margin-top: 2em;
-    margin-left: auto;
-    margin-right: auto;
-    margin-bottom: 2em;
-    display: block
+  position: relative;
+  width: 800px;
+  margin-top: 2em;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 2em;
+  display: block
 }

--- a/client/src/styles/level.css
+++ b/client/src/styles/level.css
@@ -1,125 +1,125 @@
 /* Level selector */
 
-
+  
 .level-selector-nav {
-  width: 800px;
+    width: 800px;
 }
 
 .powered-by {
-  margin-left: auto;
-  margin-top: -2em;
-  margin-bottom: -2em;
-  margin-right: auto;
-  text-align: center;
+    margin-left: auto;
+    margin-top: -2em;
+    margin-bottom: -2em;
+    margin-right: auto;
+    text-align: center;
 }
 
 
 .dropdown-menu-bar {
-  display: flex;
-  justify-content: space-between;
-  align-items:center;
-  padding: 5px 30px;
-  margin-top: 1%;
-  overflow: hidden;
-  background-color: var(--primary-color);
-  border: solid var(--secondary-color) 2px;
-  border-radius: 6px;
-  font-style: none;
-  color: var(--secondary-color);
-  font-family: Arial, Helvetica, sans-serif;
-  font-weight: bolder;
-  font-size: larger;
-  text-decoration: none;
+    display: flex;
+    justify-content: space-between;
+    align-items:center;
+    padding: 5px 30px;
+    margin-top: 1%;
+    overflow: hidden;
+    background-color: var(--primary-color);
+    border: solid var(--secondary-color) 2px;
+    border-radius: 6px;
+    font-style: none;
+    color: var(--secondary-color);
+    font-family: Arial, Helvetica, sans-serif;
+    font-weight: bolder;
+    font-size: larger;
+    text-decoration: none;
 }
 
 .button-sequence {
-  margin-bottom: 2%;
-  text-align: center;
+    margin-bottom: 2%;
+    text-align: center;
 }
 
 .level-title {
-  margin-left: 43%;
+    margin-left: 43%;
 }
 
 .dropdown-menu-bar p{
-  height: 10px;
+    height: 10px;
 }
 
 .dropdown-menu-bar-button{
-  overflow: hidden;
+    overflow: hidden;
 }
 
 .level-selector-nav a{
-  font-style: none;
-  color: var(--secondary-color);
-  font-family: Arial, Helvetica, sans-serif;
-  font-weight: normal;
-  text-decoration: none;
+    font-style: none;
+    color: var(--secondary-color);
+    font-family: Arial, Helvetica, sans-serif;
+    font-weight: normal;
+    text-decoration: none;
 }
 
 .level-selector-dropdown-content{
-  display: none;
-  padding: 5px 5px;
-  margin-top: 1%;
-  overflow: hidden;
-  border: solid var(--secondary-color) 2px;
-  border-radius: 6px;
-  margin: 1% ;
-  font-style: none;
-  color: var(--primary-color);
-  font-family: Arial, Helvetica, sans-serif;
-  font-weight: normal;
-  text-decoration: none;
-  overflow-y: auto;
-  height:400px;
+    display: none;
+    padding: 5px 5px;
+    margin-top: 1%;
+    overflow: hidden;
+    border: solid var(--secondary-color) 2px;
+    border-radius: 6px;
+    margin: 1% ;
+    font-style: none;
+    color: var(--primary-color);
+    font-family: Arial, Helvetica, sans-serif;
+    font-weight: normal;
+    text-decoration: none;
+    overflow-y: auto; 
+    height:400px;
 }
 
 .level-selector-dropdown-content-item {
-  display: flex;
-  justify-content: space-between;
-  text-align:center;
-  width: auto;
-  background-color: var(--primary-color);
-  color: var(--secondary-color);
+    display: flex;
+    justify-content: space-between;
+    text-align:center;
+    width: auto;
+    background-color: var(--primary-color);
+    color: var(--secondary-color);
 }
 
 .level-selector-dropdown-content-item a{
-  background-color: var(--primary-color);
-  color: var(--secondary-color);
-  z-index: 1;
+    background-color: var(--primary-color);
+    color: var(--secondary-color);
+    z-index: 1;
 }
 
 .dropdown-button{
-  color: var(--secondary-color);
-  background-color:var(--primary-color);
+    color: var(--secondary-color);
+    background-color:var(--primary-color);
 }
 
 .level-selector-dropdown-content-item:hover {
-  background-color: var(--secondary-color);
-  color: var(--primary-color);
-  border: solid var(--secondary-color) 2px;
-  border-radius: 6px;
+    background-color: var(--secondary-color);
+    color: var(--primary-color);
+    border: solid var(--secondary-color) 2px;
+    border-radius: 6px;
 }
 
 .level-selector-dropdown-content-item:hover a{
-  background-color: var(--secondary-color);
-  color: var(--primary-color);
+    background-color: var(--secondary-color);
+    color: var(--primary-color);
 }
 
 .level-selector-nav:hover .level-selector-dropdown-content{
-  display: block;
-  /* position: absolute; */
-  z-index: 1;
-  background-color: var(--primary-color);
+    display: block;
+    /* position: absolute; */
+    z-index: 1;
+    background-color: var(--primary-color);
 }
 
 
 .level-img-view {
-  position: relative;
-  width: 800px;
-  margin-top: 2em;
-  margin-left: auto;
-  margin-right: auto;
-  margin-bottom: 2em;
-  display: block
+    position: relative;
+    width: 800px;
+    margin-top: 2em;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 2em;
+    display: block
 }


### PR DESCRIPTION
Remove scaling down of level UI. This scaling results in the use of only 60% of the screen. Typically, this would not be much of an issue. However, the fact that this site is used with console open, leaves the user (assuming they use a horizontal console) with much less used screen space. This results in the need to unnecessarily scroll to view the source code. This PR mitigates that by statically sizing the level ui to 800px
![Scaled UI](https://user-images.githubusercontent.com/95703085/184550703-b8b31a99-186a-4f8c-b652-86d2a2b2e158.png)
![Static UI](https://user-images.githubusercontent.com/95703085/184550713-423db9fe-8d7c-460c-a935-0850fb725a84.png)
.