### PR TITLE
Fix ether value pass through in Recovery factory

### DIFF
--- a/contracts/contracts/levels/RecoveryFactory.sol
+++ b/contracts/contracts/levels/RecoveryFactory.sol
@@ -10,6 +10,8 @@ contract RecoveryFactory is Level {
   mapping (address => address) lostAddress;
 
   function createInstance(address _player) override public payable returns (address) {
+    require(msg.value >= 0.001 ether, "Must send at least 0.001 ETH");
+
     Recovery recoveryInstance;
     recoveryInstance = new Recovery();
     // create a simple token 
@@ -17,7 +19,7 @@ contract RecoveryFactory is Level {
     // the lost address
     lostAddress[address(recoveryInstance)] = address(uint160(uint256(keccak256(abi.encodePacked(uint8(0xd6), uint8(0x94), recoveryInstance, uint8(0x01))))));
     // Send it some ether
-    (bool result,) = lostAddress[address(recoveryInstance)].call{value:0.001 ether}("");
+    (bool result,) = lostAddress[address(recoveryInstance)].call{value: msg.value}("");
     require(result);
 
     return address(recoveryInstance);


### PR DESCRIPTION
Currently the Factory contract of the Recovery level attempts to send a hardcoded 0.001 ether to the "lost" `SimpleToken` instance for recovery.

This has the following issues:
1. If the user sets a msg.value of <0.001 ether and there are no other funds in the factory contract the level creation transaction will fail without revert reason.
2. If the user sets a msg.value >0.001 ether the excess amount will be "stuck" in the factory contract and not be recovered upon solving the level
3. If another user had previously committed the mistake outlined in 2. a third user can come along and obtain those left over funds by creating a level with msg.value < 0.001 ether

This PR fixes that by replacing the current logic in the Recovery factory with what is "standard" in the other level factories (such as the KingFactory) i.e.:
1. Check if user has sent minimum eth amount upon level creation (0.001 ether) and revert with informative reason if not.
2. Forward the whole `msg.value` amound to the level instance upon creation.