### PR TITLE
Update dex2.md (remove second hint, which makes the level too easy)

### DIFF
--- a/client/src/gamedata/en/descriptions/levels/dex2.md
+++ b/client/src/gamedata/en/descriptions/levels/dex2.md
@@ -7,4 +7,3 @@ You will still start with 10 tokens of `token1` and 10 of `token2`. The DEX cont
 &nbsp;
 Things that might help:
 * How has the `swap` method been modified?
-* Could you use a custom token contract in your attack?


### PR DESCRIPTION
Remove the second hint bullet point (which makes the level too easy!)

Once one realizes that any token can be used, the problem is trivial even without price manipulation. But it isn't necessary to explicitly inform players that a custom token could be used -- if the player follows the first bit of advice and does a diff between the two, they will discover that the first `require` statement (which checks if the token is a valid one) has been removed. It's not a big leap from there to realize how introducing one or two additional tokens could work. In fact, the new tokens don't even need to be modified from the given `SwappableToken` -- all one needs to do is transfer 1 token to the dex after creating the token, such that swapping from 1 of the new token to either of the original tokens yields `swapAmount = 1 * 100 / 1 = 100`.