### PR TITLE
Add link to help page in level descriptions

### DIFF
--- a/client/src/gamedata/en/descriptions/levels/coinflip.md
+++ b/client/src/gamedata/en/descriptions/levels/coinflip.md
@@ -2,4 +2,5 @@ This is a coin flipping game where you need to build up your winning streak by g
 
 &nbsp;
 Things that might help
-* See the Help page above, section "Beyond the console"
+
+- See the [Help page](https://ethernaut.openzeppelin.com/help) section "Beyond the console"

--- a/client/src/gamedata/en/descriptions/levels/force.md
+++ b/client/src/gamedata/en/descriptions/levels/force.md
@@ -4,6 +4,7 @@ The goal of this level is to make the balance of the contract greater than zero.
 
 &nbsp;
 Things that might help:
-* Fallback methods
-* Sometimes the best way to attack a contract is with another contract.
-* See the Help page above, section "Beyond the console"
+
+- Fallback methods
+- Sometimes the best way to attack a contract is with another contract.
+- See the [Help page](https://ethernaut.openzeppelin.com/help) section "Beyond the console"

--- a/client/src/gamedata/en/descriptions/levels/reentrancy.md
+++ b/client/src/gamedata/en/descriptions/levels/reentrancy.md
@@ -2,8 +2,9 @@ The goal of this level is for you to steal all the funds from the contract.
 
 &nbsp;
 Things that might help:
-* Untrusted contracts can execute code where you least expect it.
-* Fallback methods
-* Throw/revert bubbling
-* Sometimes the best way to attack a contract is with another contract.
-* See the Help page above, section "Beyond the console"
+
+- Untrusted contracts can execute code where you least expect it.
+- Fallback methods
+- Throw/revert bubbling
+- Sometimes the best way to attack a contract is with another contract.
+- See the [Help page](https://ethernaut.openzeppelin.com/help) section "Beyond the console"

--- a/client/src/gamedata/en/descriptions/levels/telephone.md
+++ b/client/src/gamedata/en/descriptions/levels/telephone.md
@@ -2,4 +2,5 @@ Claim ownership of the contract below to complete this level.
 
 &nbsp;
 Things that might help
-* See the Help page above, section "Beyond the console"
+
+- See the [Help page](https://ethernaut.openzeppelin.com/help) section "Beyond the console"

--- a/client/src/gamedata/es/descriptions/levels/coinflip.md
+++ b/client/src/gamedata/es/descriptions/levels/coinflip.md
@@ -2,4 +2,5 @@ Eso es el típico juego del lanzamiento de la moneda donde necesitaras construir
 
 &nbsp;
 Cosas que pueden ayudar
-* Mira la página de Ayuda arriba, en la sección "Más allá de la consola"
+
+- Mira la [página de Ayuda](https://ethernaut.openzeppelin.com/help), en la sección "Más allá de la consola"

--- a/client/src/gamedata/es/descriptions/levels/force.md
+++ b/client/src/gamedata/es/descriptions/levels/force.md
@@ -4,6 +4,7 @@ El objetivo de este nivel es hacer que el saldo del contrato sea mayor que cero.
 
 &nbsp;
 Cosas que pueden ayudar:
-* Métodos fallback
-* A veces, la mejor forma de atacar un contrato es con otro contrato.
-* Consulte la página de ayuda anterior, sección "Más allá de la consola"
+
+- Métodos fallback
+- A veces, la mejor forma de atacar un contrato es con otro contrato.
+- Consulte [página de Ayuda](https://ethernaut.openzeppelin.com/help), sección "Más allá de la consola"

--- a/client/src/gamedata/es/descriptions/levels/reentrancy.md
+++ b/client/src/gamedata/es/descriptions/levels/reentrancy.md
@@ -2,8 +2,9 @@ El objetivo de este nivel es que robes todos los fondos del contrato.
 
 &nbsp;
 Cosas que pueden ayudar:
-* Los contratos que no son de confianza pueden ejecutar código donde menos lo esperas.
-* Métodos fallback
-* Throw/revert
-* A veces, la mejor forma de atacar un contrato es con otro contrato.
-* Consulte la página de ayuda anterior, sección "Más allá de la consola"
+
+- Los contratos que no son de confianza pueden ejecutar código donde menos lo esperas.
+- Métodos fallback
+- Throw/revert
+- A veces, la mejor forma de atacar un contrato es con otro contrato.
+- Consulte la [página de Ayuda](https://ethernaut.openzeppelin.com/help), sección "Más allá de la consola"

--- a/client/src/gamedata/es/descriptions/levels/telephone.md
+++ b/client/src/gamedata/es/descriptions/levels/telephone.md
@@ -2,4 +2,5 @@ Reclame la propiedad del contrato a continuación para completar este nivel.
 
 &nbsp;
 Cosas que pueden ayudar
-* Consulte la página de ayuda anterior, sección "Más allá de la consola"
+
+- Consulte la [página de Ayuda](https://ethernaut.openzeppelin.com/help), sección "Más allá de la consola"

--- a/client/src/gamedata/fr/descriptions/levels/coinflip.md
+++ b/client/src/gamedata/fr/descriptions/levels/coinflip.md
@@ -2,4 +2,5 @@ Il s'agit d'un jeu de lancer de pièces où vous devez construire votre série d
 
 &nbsp;
 Choses qui pourraient aider
-* Voir la page d'aide ci-dessus, section "Au-delà de la console"
+
+- Voir la [page d'aide](https://ethernaut.openzeppelin.com/help) ci-dessus, section "Au-delà de la console"

--- a/client/src/gamedata/fr/descriptions/levels/force.md
+++ b/client/src/gamedata/fr/descriptions/levels/force.md
@@ -4,6 +4,7 @@ L'objectif de ce niveau est de rendre le solde du contrat supérieur à zéro.
 
 &nbsp;
 Voici quelques coinseils:
-* Méthodes Fallback
-* Parfois, la meilleure façon d'attaquer un contrat est avec un autre contrat.
-* Voir la page d'aide ci-dessus, section "Au-delà de la console" (Beyond the console)
+
+- Méthodes Fallback
+- Parfois, la meilleure façon d'attaquer un contrat est avec un autre contrat.
+- Voir la [page d'aide](https://ethernaut.openzeppelin.com/help) ci-dessus, section "Au-delà de la console" (Beyond the console)

--- a/client/src/gamedata/fr/descriptions/levels/reentrancy.md
+++ b/client/src/gamedata/fr/descriptions/levels/reentrancy.md
@@ -2,8 +2,9 @@ Le but de ce niveau est pour vous de voler tous les fonds du contrat.
 
 &nbsp;
 Voici quelques conseils:
-* Les contrats non approuvés peuvent exécuter du code là où vous vous y attendez le moins.
-* Méthodes de fallback
-* Throw/revert bubbling
-* Parfois, la meilleure façon d'attaquer un contrat est avec un autre contrat.
-* Voir la page d'aide ci-dessus, section "Au-delà de la console" ("Beyond the console")
+
+- Les contrats non approuvés peuvent exécuter du code là où vous vous y attendez le moins.
+- Méthodes de fallback
+- Throw/revert bubbling
+- Parfois, la meilleure façon d'attaquer un contrat est avec un autre contrat.
+- Voir la [page d'aide](https://ethernaut.openzeppelin.com/help) ci-dessus, section "Au-delà de la console" ("Beyond the console")

--- a/client/src/gamedata/fr/descriptions/levels/telephone.md
+++ b/client/src/gamedata/fr/descriptions/levels/telephone.md
@@ -2,4 +2,5 @@ Réclamez le contrat ci-dessous pour terminer ce niveau.
 
 &nbsp;
 Voici quelques conseils:
-* See the Help page above, section "Beyond the console"
+
+- See the [Help page](https://ethernaut.openzeppelin.com/help) section "Beyond the console"


### PR DESCRIPTION
PR to address #558 in several translations/levels. The page must have been reformatted because the wording says 'help page above'