### PR TITLE
UX Enhancement, Level Dropdown Behavior, remove onMouseLeave

### DIFF
--- a/client/src/containers/Level.js
+++ b/client/src/containers/Level.js
@@ -24,7 +24,6 @@ class Level extends React.Component {
       dropwDownOpened: false,
     };
     this.containerRef = createRef();
-    this.handleClickOutside = this.handleClickOutside.bind(this);
   }
 
   componentDidMount() {
@@ -82,7 +81,7 @@ class Level extends React.Component {
     }
   };
 
-  handleClickOutside(event) {
+  handleClickOutside = (event) => {
     if (this.containerRef && !this.containerRef.current.contains(event.target)) {
       this.closeDropdown();
     }
@@ -173,7 +172,7 @@ class Level extends React.Component {
 
               <div className="dropdown-menu-bar-button">
                 <button className="dropdown-button">
-                  <i className="fa fa-caret-down"></i>
+                  <i className={`fa fa-caret-${this.state.dropwDownOpened? "up" : "down"}`}></i>
                 </button>
               </div>
             </div>

--- a/client/src/containers/Level.js
+++ b/client/src/containers/Level.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { createRef } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import CodeComponent from "../components/levels/Code";
@@ -13,7 +13,7 @@ import getlevelsdata from "../utils/getlevelsdata";
 import { withRouter } from "../hoc/withRouter";
 import { getLevelKey } from "../utils/contractutil";
 import { deployAndRegisterLevel } from "../utils/deploycontract";
-import {  svgFilter } from "../utils/svg";
+import { svgFilter } from "../utils/svg";
 
 class Level extends React.Component {
   constructor(props) {
@@ -23,16 +23,20 @@ class Level extends React.Component {
       submittedIntance: false,
       dropwDownOpened: false,
     };
+    this.containerRef = createRef();
+    this.handleClickOutside = this.handleClickOutside.bind(this);
   }
 
   componentDidMount() {
     this.props.activateLevel(this.props.params.address);
+    document.addEventListener("mousedown", this.handleClickOutside);
   }
 
   componentWillUnmount() {
     if (this.props.activateLevel) {
       this.props.deactivateLevel(this.props.activateLevel);
     }
+    document.removeEventListener("mousedown", this.handleClickOutside);
   }
 
   componentDidUpdate() {
@@ -60,10 +64,7 @@ class Level extends React.Component {
     if (!this.state.requestedInstance) {
       this.props.loadLevelInstance(this.props.level, false, true);
       this.setState({ requestedInstance: true });
-      setTimeout(
-        () => this.setState({ requestedInstance: false }),
-        2000
-      );
+      setTimeout(() => this.setState({ requestedInstance: false }), 2000);
     }
   };
 
@@ -74,10 +75,16 @@ class Level extends React.Component {
   };
 
   closeDropdown = () => {
-    if(this.state.dropwDownOpened){
+    if (this.state.dropwDownOpened) {
       this.setState({
-        dropwDownOpened: false
+        dropwDownOpened: false,
       });
+    }
+  };
+
+  handleClickOutside(event) {
+    if (this.containerRef && !this.containerRef.current.contains(event.target)) {
+      this.closeDropdown();
     }
   }
 
@@ -144,7 +151,7 @@ class Level extends React.Component {
     const nextLevelId = findNextLevelId(this.props.level, this.props.levels);
 
     return (
-      <main onClick={this.closeDropdown}>
+      <main>
         <div className="lines"></div>
         <main>
           {(isDescriptionMissingTranslation ||
@@ -159,7 +166,7 @@ class Level extends React.Component {
               </div>
             )}
 
-          <div onMouseLeave={this.closeDropdown} onClick={e => e.stopPropagation()} className="level-selector-nav">
+          <div ref={this.containerRef} onClick={e => e.stopPropagation()} className="level-selector-nav">
             <div onClick={this.toggleDropdown} className="dropdown-menu-bar">
               <p key={level.difficulty}>{selectedLevel.difficulty}</p>
               <p key={level.name}>{level.name}</p>
@@ -170,13 +177,14 @@ class Level extends React.Component {
                 </button>
               </div>
             </div>
-            <div style={{display: this.state.dropwDownOpened ? 'block':'none'}} className="level-selector-dropdown-content">
+            <div style={{ display: this.state.dropwDownOpened ? 'block' : 'none' }} className="level-selector-dropdown-content">
               {levelData.map((level) => {
                 return (
                   <Link
                     key={level.name}
                     to={`${constants.PATH_LEVEL_ROOT}${level.deployedAddress || level.id
                       }`}
+                    onClick={this.closeDropdown}
                   >
                     <div className="level-selector-dropdown-content-item">
                       <p key={level.name}>


### PR DESCRIPTION
I was going through Ethernaut and experienced some problems with the dropdown behavior, that is, immediate close on mouse leaving the dropdown.

This PR aims to:
- give a better experience to users on higher DPI monitors
- better support for non-standard pointing devices
- overall improve accessibility by giving the dropdown an expected behavior

Changes:
- removed `onMouseLeave`
- added a `onClickOutside` behavior to the close the dropdown on clicks outside `level-selector-nav` div
- removed `onClick={this.closeDropdown}` from `<main>`, this is completely replaced by the `onClickOutside` behavior
I suppose this was done to account for mobile devices, but two considerations have to be made:
  - The whole experience is not engineered for mobile users
  - this change maintains previous mobile behavior and allows for a more appropriate experience on tablets in landscape mode (see [screenshot](https://i.imgur.com/cSpgV53.png))
- added `onClick={this.closeDropdown}` to the `<Link>` buttons, so that the dropdown is closed on page change

This PR has been tested on  Google Chrome 110.0.5481.77 for Windows 10 and Google Chrome 110.0.5481.65 for Android 11