### PR TITLE
unnecessary boolean initialization to false

### DIFF
--- a/contracts/contracts/levels/GatekeeperThree.sol
+++ b/contracts/contracts/levels/GatekeeperThree.sol
@@ -32,7 +32,7 @@ contract SimpleTrick {
 contract GatekeeperThree {
   address public owner;
   address public entrant;
-  bool public allow_enterance = false;
+  bool public allow_enterance;
   SimpleTrick public trick;
 
   function construct0r() public {


### PR DESCRIPTION
Solidity initializes booleans to false (0x00) by default, so the assignment in line 35 of allow_enterance to false at contract deployment time is redundant and unnecessary.

Enjoyed the level :)