### PR TITLE
Fix links, and lightly rephrase dex_complete.md

### DIFF
--- a/client/src/gamedata/en/descriptions/levels/dex_complete.md
+++ b/client/src/gamedata/en/descriptions/levels/dex_complete.md
@@ -1,47 +1,58 @@
 The integer math portion aside, getting prices or any sort of data from any single source is a massive attack vector in smart contracts. 
 
-You can clearly see from this example, that someone with a lot of capital could manipulate the price in one fell swoop, and cause any applications relying on it to use the the wrong price.
+You can clearly see from this example, that someone with a lot of capital could manipulate the price in one fell swoop, and cause any applications relying on it to use the the wrong price. 
 
-The exchange itself is decentralized, but the price of the asset is centralized, since it comes from 1 dex. This is why we need [oracles](https://betterprogramming.pub/what-is-a-blockchain-oracle-f5ccab8dbd72?source=friends_link&sk=d921a38466df8a9176ed8dd767d8c77d). Oracles are ways to get data into and out of smart contracts. We should be getting our data from multiple independent decentralized sources, otherwise we can run this risk. 
+The exchange itself is decentralized, but the price of the asset is centralized, since it comes from 1 dex. However, if we were to consider tokens that represent actual assets rather than fictitious ones, most of them would have exchange pairs in several dexes and networks. This would decrease the effect on the asset's price in case a specific dex is targeted by an attack like this.
+
+[Oracles](https://betterprogramming.pub/what-is-a-blockchain-oracle-f5ccab8dbd72?source=friends_link&sk=d921a38466df8a9176ed8dd767d8c77d) are used to get data into and out of smart contracts. 
 
 [Chainlink Data Feeds](https://docs.chain.link/docs/get-the-latest-price) are a secure, reliable, way to get decentralized data into your smart contracts. They have a vast library of many different sources, and also offer [secure randomness](https://docs.chain.link/docs/chainlink-vrf), ability to make [any API call](https://docs.chain.link/docs/make-a-http-get-request), [modular oracle network creation](https://docs.chain.link/docs/architecture-decentralized-model), [upkeep, actions, and maintainance](https://docs.chain.link/docs/kovan-keeper-network-beta), and unlimited customization. 
 
-[Uniswap TWAP Oracles](https://uniswap.org/docs/v2/core-concepts/oracles/) relies on a time weighted price model called [TWAP](https://en.wikipedia.org/wiki/Time-weighted_average_price#). While the design can be attractive, this protocol heavily depends on the liquidity of the DEX protocol, and if this is too low, prices can be easily manipulated. 
+[Uniswap TWAP Oracles](https://docs.uniswap.org/contracts/v2/concepts/core-concepts/oracles) relies on a time weighted price model called [TWAP](https://en.wikipedia.org/wiki/Time-weighted_average_price#). While the design can be attractive, this protocol heavily depends on the liquidity of the DEX protocol, and if this is too low, prices can be easily manipulated. 
 
 
-Here is an example of getting data from a Chainlink data feed (on the kovan testnet):
+Here is an example of getting the price of Bitcoin in USD from a Chainlink data feed (on the Sepolia testnet):
+
 ```
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.7;
 
-pragma solidity ^0.6.7;
-
-import "@chainlink/contracts/src/v0.6/interfaces/AggregatorV3Interface.sol";
+import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 
 contract PriceConsumerV3 {
-
     AggregatorV3Interface internal priceFeed;
 
     /**
-     * Network: Kovan
-     * Aggregator: ETH/USD
-     * Address: 0x9326BFA02ADD2366b30bacB125260Af641031331
+     * Network: Sepolia
+     * Aggregator: BTC/USD
+     * Address: 0x1b44F3514812d835EB1BDB0acB33d3fA3351Ee43
      */
-    constructor() public {
-        priceFeed = AggregatorV3Interface(0x9326BFA02ADD2366b30bacB125260Af641031331);
+    constructor() {
+        priceFeed = AggregatorV3Interface(
+            0x1b44F3514812d835EB1BDB0acB33d3fA3351Ee43
+        );
     }
 
     /**
-     * Returns the latest price
+     * Returns the latest price.
      */
     function getLatestPrice() public view returns (int) {
+        // prettier-ignore
         (
-            uint80 roundID, 
+            /* uint80 roundID */,
             int price,
-            uint startedAt,
-            uint timeStamp,
-            uint80 answeredInRound
+            /*uint startedAt*/,
+            /*uint timeStamp*/,
+            /*uint80 answeredInRound*/
         ) = priceFeed.latestRoundData();
         return price;
     }
 }
+
 ```
-[Try it on Remix](https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&gist=0c5928a00094810d2ba01fd8d1083581)
+[Try it on Remix](https://remix.ethereum.org/#url=https://docs.chain.link/samples/PriceFeeds/PriceConsumerV3.sol)
+
+Check the Chainlink feed [page](https://data.chain.link/ethereum/mainnet/crypto-usd/btc-usd) to see that the price of Bitcoin is queried from up to 31 different sources.
+
+You can check also, the [list](https://docs.chain.link/data-feeds/price-feeds/addresses/) all Chainlink price feeds addresses.
+

--- a/client/src/gamedata/es/descriptions/levels/dex_complete.md
+++ b/client/src/gamedata/es/descriptions/levels/dex_complete.md
@@ -2,45 +2,55 @@ Dejando a un lado la parte matemática, obtener precios o cualquier tipo de dato
 
 Puedes ver claramente en este ejemplo que alguien con mucho capital podría manipular el precio de una sola vez y hacer que cualquier aplicación que dependa de él use el precio incorrecto.
 
-El exchange en sí está descentralizado, pero el precio del activo está centralizado, ya que proviene de 1 dex. Es por eso que necesitamos [oráculos](https://betterprogramming.pub/what-is-a-blockchain-oracle-f5ccab8dbd72?source=friends_link&sk=d921a38466df8a9176ed8dd767d8c77d). Los oráculos son formas de introducir y extraer datos de los contratos inteligentes. Deberíamos siempre obtener nuestros datos de múltiples fuentes descentralizadas independientes, de lo contrario, podemos correr este riesgo.
+El exchange en sí está descentralizado, pero el precio del activo está centralizado, ya que proviene de 1 dex. Sin embargo, si consideramos tokens que representan activos reales en lugar de ficticios, la mayoría tendría pares de intercambio en varias dex y diferentes redes. Esto reduciría el impacto en el precio del activo en caso de que una dex específica sufriera un ataque de este tipo.
+
+
+Los [oráculos](https://betterprogramming.pub/what-is-a-blockchain-oracle-f5ccab8dbd72?source=friends_link&sk=d921a38466df8a9176ed8dd767d8c77d) son formas de introducir y extraer datos de los contratos inteligentes.
 
 [Chainlink Data Feeds](https://docs.chain.link/docs/get-the-latest-price) es una forma segura y confiable de obtener datos descentralizados en los contratos inteligentes. Tienen una amplia biblioteca de muchas fuentes diferentes, y también ofrecen [secure randomness](https://docs.chain.link/docs/chainlink-vrf), capacidad para realizar [cualquier llamada API](https://docs.chain.link/docs/make-a-http-get-request), [modular oracle network creation](https://docs.chain.link/docs/architecture-decentralized-model), [upkeep, actions, and maintainance](https://docs.chain.link/docs/kovan-keeper-network-beta) y personalización ilimitada.
 
-[Uniswap TWAP Oracles](https://uniswap.org/docs/v2/core-concepts/oracles/) se basa en un modelo de precio ponderado por tiempo llamado [TWAP] (https://en.wikipedia.org/wiki/Time-weighted_average_price#). Si bien el diseño puede ser atractivo, este protocolo depende en gran medida de la liquidez del protocolo DEX y, si es demasiado bajo, los precios se pueden manipular fácilmente.
+[Uniswap TWAP Oracles](https://docs.uniswap.org/contracts/v2/concepts/core-concepts/oracles) se basa en un modelo de precio ponderado por tiempo llamado [TWAP](https://en.wikipedia.org/wiki/Time-weighted_average_price#). Si bien el diseño puede ser atractivo, este protocolo depende en gran medida de la liquidez del protocolo DEX y, si es demasiado bajo, los precios se pueden manipular fácilmente.
 
-A continuación, se muestra un ejemplo de cómo obtener datos de un feed de datos de Chainlink (en la red de prueba de kovan):
+A continuación, se muestra un ejemplo de cómo obtener el precio de Bitcoin en USD de un feed de datos de Chainlink (en la red de prueba de Sepolia):
 ```
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.7;
 
-pragma solidity ^0.6.7;
-
-import "@chainlink/contracts/src/v0.6/interfaces/AggregatorV3Interface.sol";
+import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 
 contract PriceConsumerV3 {
-
     AggregatorV3Interface internal priceFeed;
 
     /**
-     * Network: Kovan
-     * Aggregator: ETH/USD
-     * Address: 0x9326BFA02ADD2366b30bacB125260Af641031331
+     * Network: Sepolia
+     * Aggregator: BTC/USD
+     * Address: 0x1b44F3514812d835EB1BDB0acB33d3fA3351Ee43
      */
-    constructor() public {
-        priceFeed = AggregatorV3Interface(0x9326BFA02ADD2366b30bacB125260Af641031331);
+    constructor() {
+        priceFeed = AggregatorV3Interface(
+            0x1b44F3514812d835EB1BDB0acB33d3fA3351Ee43
+        );
     }
 
     /**
-     * Returns the latest price
+     * Returns the latest price.
      */
     function getLatestPrice() public view returns (int) {
+        // prettier-ignore
         (
-            uint80 roundID, 
+            /* uint80 roundID */,
             int price,
-            uint startedAt,
-            uint timeStamp,
-            uint80 answeredInRound
+            /*uint startedAt*/,
+            /*uint timeStamp*/,
+            /*uint80 answeredInRound*/
         ) = priceFeed.latestRoundData();
         return price;
     }
 }
+
 ```
-[Prueba en Remix](https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&gist=0c5928a00094810d2ba01fd8d1083581)
+[Prueba en Remix](https://remix.ethereum.org/#url=https://docs.chain.link/samples/PriceFeeds/PriceConsumerV3.sol)
+
+Comprueba en la [página](https://data.chain.link/ethereum/mainnet/crypto-usd/btc-usd) del feed cómo se consulta el precio en hasta 31 fuentes diferentes.
+
+También puedes comprobar la [lista](https://docs.chain.link/data-feeds/price-feeds/addresses/) de todos los feeds de precios de Chainlink.

--- a/client/src/gamedata/ja/descriptions/levels/dex_complete.md
+++ b/client/src/gamedata/ja/descriptions/levels/dex_complete.md
@@ -6,43 +6,46 @@
 
 [Chainlink Data Feeds](https://docs.chain.link/docs/get-the-latest-price)は、分散型データをスマートコントラクトに取り込むための、安全で信頼できる方法です。多くの異なるソースからなる膨大なライブラリを持ち、[安全なランダム性](https://docs.chain.link/docs/chainlink-vrf)、[任意の API コール](https://docs.chain.link/docs/make-a-http-get-request)、[モジュラーオラクルネットワークの作成](https://docs.chain.link/docs/architecture-decentralized-model)、[アップキープ、アクション、メンテナンス](https://docs.chain.link/docs/kovan-keeper-network-beta)、そして自由なカスタマイズも可能です。
 
-[Uniswap TWAP Oracles](https://uniswap.org/docs/v2/core-concepts/oracles/)は、[TWAP](https://en.wikipedia.org/wiki/Time-weighted_average_price#)と呼ばれる時間加重価格モデルに依存しています。魅力的なデザインではありますが、このプロトコルは DEX プロトコルの流動性に大きく依存しており、流動性が低すぎると価格が簡単に操作されてしまいます。
+[Uniswap TWAP Oracles](https://docs.uniswap.org/contracts/v2/concepts/core-concepts/oracles)は、[TWAP](https://en.wikipedia.org/wiki/Time-weighted_average_price#)と呼ばれる時間加重価格モデルに依存しています。魅力的なデザインではありますが、このプロトコルは DEX プロトコルの流動性に大きく依存しており、流動性が低すぎると価格が簡単に操作されてしまいます。
 
-ここでは、Chainlink のデータフィードからデータを取得する例を紹介します（kovan testnet）:
+ここでは、Chainlink のデータフィードからデータを取得する例を紹介します（Sepolia testnet）:
 
 ```
 
-pragma solidity ^0.6.7;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.7;
 
-import "@chainlink/contracts/src/v0.6/interfaces/AggregatorV3Interface.sol";
+import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 
 contract PriceConsumerV3 {
-
     AggregatorV3Interface internal priceFeed;
 
     /**
-     * Network: Kovan
-     * Aggregator: ETH/USD
-     * Address: 0x9326BFA02ADD2366b30bacB125260Af641031331
+     * Network: Sepolia
+     * Aggregator: BTC/USD
+     * Address: 0x1b44F3514812d835EB1BDB0acB33d3fA3351Ee43
      */
-    constructor() public {
-        priceFeed = AggregatorV3Interface(0x9326BFA02ADD2366b30bacB125260Af641031331);
+    constructor() {
+        priceFeed = AggregatorV3Interface(
+            0x1b44F3514812d835EB1BDB0acB33d3fA3351Ee43
+        );
     }
 
     /**
-     * Returns the latest price
+     * Returns the latest price.
      */
     function getLatestPrice() public view returns (int) {
+        // prettier-ignore
         (
-            uint80 roundID,
+            /* uint80 roundID */,
             int price,
-            uint startedAt,
-            uint timeStamp,
-            uint80 answeredInRound
+            /*uint startedAt*/,
+            /*uint timeStamp*/,
+            /*uint80 answeredInRound*/
         ) = priceFeed.latestRoundData();
         return price;
     }
 }
 ```
 
-[Try it on Remix](https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&gist=0c5928a00094810d2ba01fd8d1083581)
+[Try it on Remix](https://remix.ethereum.org/#url=https://docs.chain.link/samples/PriceFeeds/PriceConsumerV3.sol)

--- a/client/src/gamedata/ru/descriptions/levels/dex_complete.md
+++ b/client/src/gamedata/ru/descriptions/levels/dex_complete.md
@@ -6,42 +6,45 @@
 
 [Chainlink Data Feeds](https://docs.chain.link/docs/get-the-latest-price) (Каналы данных Chainlink) — безопасный, надёжный способ получения децентрализованных данных из смарт контрактов. Они располагают обширной библиотекой из множества различных источников, а также предлагают [надёжную случайную информацию](https://docs.chain.link/docs/chainlink-vrf), возможность сделать [любой API call](https://docs.chain.link/docs/make-a-http-get-request), [создание модульной сети oracle](https://docs.chain.link/docs/architecture-decentralized-model), [автоматизацию действий смарт-контрактов](https://docs.chain.link/docs/kovan-keeper-network-beta), and unlimited customization. 
 
-[Оракулы Uniswap TWAP](https://uniswap.org/docs/v2/core-concepts/oracles/) полагаются на взвешенную по времени ценовую модель, называемую [TWAP](https://en.wikipedia.org/wiki/Time-weighted_average_price#). Хотя такой дизайн может показаться привлекательным, этот протокол сильно зависит от ликвидности DEX (децентрализованной биржи), и, если она слишком низкая, ценами можно легко манипулировать.
+[Оракулы Uniswap TWAP](https://docs.uniswap.org/contracts/v2/concepts/core-concepts/oracles) полагаются на взвешенную по времени ценовую модель, называемую [TWAP](https://en.wikipedia.org/wiki/Time-weighted_average_price#). Хотя такой дизайн может показаться привлекательным, этот протокол сильно зависит от ликвидности DEX (децентрализованной биржи), и, если она слишком низкая, ценами можно легко манипулировать.
 
 
-Вот пример получения данных из канала данных Chainlink (в тестовой сети kovan):
+Вот пример получения данных из канала данных Chainlink (в тестовой сети Sepolia):
 ```
 
-pragma solidity ^0.6.7;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.7;
 
-import "@chainlink/contracts/src/v0.6/interfaces/AggregatorV3Interface.sol";
+import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 
 contract PriceConsumerV3 {
-
     AggregatorV3Interface internal priceFeed;
 
     /**
-     * Network: Kovan
-     * Aggregator: ETH/USD
-     * Address: 0x9326BFA02ADD2366b30bacB125260Af641031331
+     * Network: Sepolia
+     * Aggregator: BTC/USD
+     * Address: 0x1b44F3514812d835EB1BDB0acB33d3fA3351Ee43
      */
-    constructor() public {
-        priceFeed = AggregatorV3Interface(0x9326BFA02ADD2366b30bacB125260Af641031331);
+    constructor() {
+        priceFeed = AggregatorV3Interface(
+            0x1b44F3514812d835EB1BDB0acB33d3fA3351Ee43
+        );
     }
 
     /**
-     * Returns the latest price
+     * Returns the latest price.
      */
     function getLatestPrice() public view returns (int) {
+        // prettier-ignore
         (
-            uint80 roundID, 
+            /* uint80 roundID */,
             int price,
-            uint startedAt,
-            uint timeStamp,
-            uint80 answeredInRound
+            /*uint startedAt*/,
+            /*uint timeStamp*/,
+            /*uint80 answeredInRound*/
         ) = priceFeed.latestRoundData();
         return price;
     }
 }
 ```
-[Попробуй в IDE Remix](https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&gist=0c5928a00094810d2ba01fd8d1083581)
+[Попробуй в IDE Remix](https://remix.ethereum.org/#url=https://docs.chain.link/samples/PriceFeeds/PriceConsumerV3.sol)

--- a/client/src/gamedata/zh_cn/descriptions/levels/dex_complete.md
+++ b/client/src/gamedata/zh_cn/descriptions/levels/dex_complete.md
@@ -8,38 +8,44 @@ Chainlink 数据馈送是一种安全、可靠的方式，可以将去中心化�
 
 Uniswap TWAP 预言机依赖于称为 TWAP 的时间加权价格模型。虽然设计很有吸引力，但该协议在很大程度上取决于 DEX 协议的流动性，如果流动性太低，价格很容易被操纵。
 
-以下是从 Chainlink 数据源（在 kovan 测试网上）获取数据的示例：
+以下是从 Chainlink 数据源（在 Sepolia 测试网上）获取数据的示例：
 
 ```
-pragma solidity ^0.6.7;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.7;
 
-import "@chainlink/contracts/src/v0.6/interfaces/AggregatorV3Interface.sol";
+import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 
 contract PriceConsumerV3 {
-
     AggregatorV3Interface internal priceFeed;
 
     /**
-     * Network: Kovan
-     * Aggregator: ETH/USD
-     * Address: 0x9326BFA02ADD2366b30bacB125260Af641031331
+     * Network: Sepolia
+     * Aggregator: BTC/USD
+     * Address: 0x1b44F3514812d835EB1BDB0acB33d3fA3351Ee43
      */
-    constructor() public {
-        priceFeed = AggregatorV3Interface(0x9326BFA02ADD2366b30bacB125260Af641031331);
+    constructor() {
+        priceFeed = AggregatorV3Interface(
+            0x1b44F3514812d835EB1BDB0acB33d3fA3351Ee43
+        );
     }
 
     /**
-     * Returns the latest price
+     * Returns the latest price.
      */
     function getLatestPrice() public view returns (int) {
+        // prettier-ignore
         (
-            uint80 roundID, 
+            /* uint80 roundID */,
             int price,
-            uint startedAt,
-            uint timeStamp,
-            uint80 answeredInRound
+            /*uint startedAt*/,
+            /*uint timeStamp*/,
+            /*uint80 answeredInRound*/
         ) = priceFeed.latestRoundData();
         return price;
     }
 }
+
 ```
+
+[尝试在 Remix 上](https://remix.ethereum.org/#url=https://docs.chain.link/samples/PriceFeeds/PriceConsumerV3.sol)


### PR DESCRIPTION
Solves https://github.com/OpenZeppelin/ethernaut/issues/631

- Fixed, rephrased, and slightly expanded for en and es.
- jap and ru links fixed but text is outdated.
- It seems that the zh_cn text is outdated.