### PR TITLE
refactor: remove `pragma experimental ABIEncoderV2`

### DIFF
--- a/contracts/contracts/levels/PuzzleWallet.sol
+++ b/contracts/contracts/levels/PuzzleWallet.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
-pragma experimental ABIEncoderV2;
 
 import "../helpers/UpgradeableProxy-08.sol";
 


### PR DESCRIPTION
[Since Solidity 0.8.0, abi encoder defaults to v2](https://docs.soliditylang.org/en/v0.8.20/layout-of-source-files.html#abiencoderv2), so I think removing this line would be better for learners. (A friend of mine asked me yesterday about this line.) Thanks.