### PR TITLE
Fix for "TypeError: Cannot read properties of undefined (reading 'unshift')"

### DIFF
--- a/client/src/utils/ethutil.js
+++ b/client/src/utils/ethutil.js
@@ -205,14 +205,14 @@ export const logger = (req, res, next, end) => {
 
 export const attachLogger = () => {
   if (web3.currentProvider._rpcEngine) {
-    web3.currentProvider._rpcEngine._middleware.unshift(logger);
+    web3.currentProvider._rpcEngine.push(logger);
     return;
   }  //If the current provider hasn't an RPC Engine look for other providers
   else if (web3.currentProvider.providers) {
     var providers = web3.currentProvider.providers;
     for (var i = 0; i < providers.length; i++) {
       if (providers[i]._rpcEngine) {
-        providers[i]._rpcEngine._middleware.unshift(logger);
+        providers[i]._rpcEngine.push(logger);
 
         // Set this provider as current provider
         web3.currentProvider = providers[i];


### PR DESCRIPTION
Fixes the issue described in #686

The issue is because of the change in this [pr](https://github.com/MetaMask/json-rpc-engine/pull/139/files#diff-34a55b55a3c191567b7aedb60c053a2b2c7c0743a1b8758fe2c85e03c75d329a) where `_middleware` is changed to `#middleware` and can only be modified using the push method.