### PR TITLE
📝 (stake.md): Fix typo in Stake level description

### DIFF
--- a/client/src/gamedata/en/descriptions/levels/stake.md
+++ b/client/src/gamedata/en/descriptions/levels/stake.md
@@ -2,11 +2,12 @@ Stake is safe for staking native ETH and ERC20 WETH, considering the same 1:1 va
 
 To complete this level, the contract state must meet the following conditions:
 
-* The `Stake` contract's ETH balance has to be greater than 0.
-* `totalStaked` must be greater than the `Stake` contract's ETH balance.
-* You must be a staker.
-* You staked balance must be 0.
+- The `Stake` contract's ETH balance has to be greater than 0.
+- `totalStaked` must be greater than the `Stake` contract's ETH balance.
+- You must be a staker.
+- Your staked balance must be 0.
 
 Things that might be useful:
-* [ERC-20](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md) specification.
-* [OpenZeppelin contracts](https://github.com/OpenZeppelin/openzeppelin-contracts)
+
+- [ERC-20](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md) specification.
+- [OpenZeppelin contracts](https://github.com/OpenZeppelin/openzeppelin-contracts)


### PR DESCRIPTION
Maybe the smallest PR ever seen to fix this tiny typo on the new level 31 - Stake.
The English description was edited as follows:

```diff
- You staked balance must be 0.
+ Your staked balance must be 0.
```

And... that's it!