### PR TITLE
:hammer: Fix `@truffle/contract` dependency to `4.6.6` 

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,7 @@
     "prompt": "^1.3.0",
     "rainbow-color": "^2.0.0",
     "react": "18.2.0",
-    "react-dom": "^18.2.0",
+    "react-dom": "18.2.0",
     "react-ga": "^3.3.0",
     "react-markdown": "^8.0.0",
     "react-onclickoutside": "^6.12.2",

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@sentry/react": "^7.0.0",
     "@sentry/tracing": "^7.108.0",
-    "@truffle/contract": "^4.3.15",
+    "@truffle/contract": "4.6.6",
     "@truffle/hdwallet-provider": "^2.1.15",
     "alchemy-sdk": "^2.2.3",
     "axios": "^1.2.4",


### PR DESCRIPTION
- closes: https://github.com/OpenZeppelin/ethernaut/issues/736