### PR TITLE
Fixed Link

### DIFF
--- a/client/src/gamedata/en/descriptions/levels/stake.md
+++ b/client/src/gamedata/en/descriptions/levels/stake.md
@@ -9,5 +9,5 @@ To complete this level, the contract state must meet the following conditions:
 
 Things that might be useful:
 
-- [ERC-20](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md) specification.
+- [ERC-20](https://github.com/ethereum/ercs/blob/master/ERCS/erc-20.md) specification.
 - [OpenZeppelin contracts](https://github.com/OpenZeppelin/openzeppelin-contracts)


### PR DESCRIPTION
This change has been done to update the previous link as the ERC20 specification has been moved which has been mentioned in the [previous link](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md).
Thus, the user won't need to reach the exact link using 2 clicks instead of 1

Thanks!