### PR TITLE
Refactor: Replace deprecated `Address.isContract()` with `dest_.code.length > 0`

### DIFF
--- a/contracts/src/levels/GoodSamaritan.sol
+++ b/contracts/src/levels/GoodSamaritan.sol
@@ -48,7 +48,7 @@ contract Coin {
             balances[msg.sender] -= amount_;
             balances[dest_] += amount_;
 
-            if (dest_.isContract()) {
+            if (dest_.code.length > 0) {
                 // notify contract
                 INotifyable(dest_).notify(amount_);
             }


### PR DESCRIPTION
While working on the `Good Samaritan` challenge, I encountered an error in Visual Studio Code indicating that the `.isContract()` function is no longer available in the Address library.

![Screenshot 2024-07-15 143548](https://github.com/user-attachments/assets/9098f4a4-b3df-45b7-8d24-9a20d5d0bc0e)

Found [this pull request](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3945) in the OpenZeppelin repository, which details the removal of the `.isContract()` function. The recommended approach is to use `address(...).code.length > 0` instead...

Thanks!