### PR TITLE
Update the DetectionBot of DoubleEntryPoint challenge and the validateInstance of the DoubleEntryPointFactory

### DIFF
--- a/contracts/src/attacks/DetectionBot.sol
+++ b/contracts/src/attacks/DetectionBot.sol
@@ -13,15 +13,27 @@ interface IForta {
 
 contract DetectionBot is IDetectionBot {
     IForta public fortaContract;
+    address public cryptoVaultContract;
 
-    constructor(address forta) {
+    constructor(address forta, address cryptoVault) {
         fortaContract = IForta(forta);
+        cryptoVaultContract = cryptoVault;
     }
 
     function handleTransaction(address user, bytes calldata msgData) public override {
         // Only the Forta contract can call this method
         require(msg.sender == address(fortaContract), "Unauthorized");
-        fortaContract.raiseAlert(user);
-        msgData;
+
+        // Decode the parameters of the delegateTransfer method
+        (, , address origSender) = abi.decode(
+            msgData[4:],
+            (address, uint256, address)
+        );
+
+        // The origSender mustn't be the CryptoVault
+        // because DoubleEntryPoint is an underlying token,
+        // if so raise an alert
+        if (origSender == cryptoVaultContract)
+            fortaContract.raiseAlert(user);
     }
 }

--- a/contracts/src/levels/DoubleEntryPointFactory.sol
+++ b/contracts/src/levels/DoubleEntryPointFactory.sol
@@ -47,6 +47,13 @@ contract DoubleEntryPointFactory is Level {
     }
 
     function __trySweep(CryptoVault cryptoVault, DoubleEntryPoint instance) external returns (bool, bytes memory) {
+        // emulate a lambda transfer of a user
+        try LegacyToken(instance.delegatedFrom()).transfer(address(cryptoVault), 0) {
+        } catch {
+            // It mustn't revert, if so return true on failure
+            return (true, abi.encode(false));
+        }
+
         try cryptoVault.sweepToken(IERC20(instance.delegatedFrom())) {
             return (true, abi.encode(false));
         } catch {

--- a/contracts/test/levels/DoubleEntryPoint.t.sol
+++ b/contracts/test/levels/DoubleEntryPoint.t.sol
@@ -56,7 +56,8 @@ contract TestDoubleEntryPoint is Test, Utils {
         vm.startPrank(player);
 
         Forta forta = instance.forta();
-        DetectionBot bot = new DetectionBot(address(forta));
+        address cryptoVault = instance.cryptoVault();
+        DetectionBot bot = new DetectionBot(address(forta), cryptoVault);
 
         forta.setDetectionBot(address(bot));
 


### PR DESCRIPTION
I will speak about the `DoubleEntryPoint` challenge, the one which use `Forta`.

Currently, this is the solution of this challenge:
```solidity
    function handleTransaction(address user, bytes calldata msgData) public override {
        // Only the Forta contract can call this method
        require(msg.sender == address(fortaContract), "Unauthorized");
        fortaContract.raiseAlert(user);
        msgData;
    }
```
With this solution, the method `raiseAlert` is called all the time which makes revert the `delegateTransfer` method at each call. In my opinion, it makes no sense to have a method which reverts always.

According to me, the real exploit is to call the `delegateTransfer` method from the `CryptoVault` contract because `DoubleEntryPoint` is an underlying token. It can happend if someone call `sweepToken` method with `LegacyToken` address in parameter. The `DetectionBot` must prevent of this case. So this is my proposition of solution:
```solidity
    function handleTransaction(address user, bytes calldata msgData) public override {
        // Only the Forta contract can call this method
        require(msg.sender == address(fortaContract), "Unauthorized");

        // Decode the parameters of the delegateTransfer method
        (, , address origSender) = abi.decode(
            msgData[4:],
            (address, uint256, address)
        );

        // The origSender mustn't be the CryptoVault
        // because DoubleEntryPoint is an underlying token,
        // if so raise an alert
        if (origSender == cryptoVaultContract)
            fortaContract.raiseAlert(user);
    }
```
With this solution, the method `raiseAlert` is called only when the vulnerability is exploited.

Now, to prevent someone to solve this challenge with a `DetectionBot` which raises an alert all the time. I also updated the `validateInstance` method of the `DoubleEntryPointFactory`. Before trying to sweep token, the `validateInstance` method will try to emulate a lambda transfer of a user, if the transfer reverts, the `validateInstance` fails.

I updated unit tests to test my code. I also deployed the new `DoubleEntryPointFactory` in local environment to test it through ethernaut. Everything is working!

Do I have to push the new build of the `DoubleEntryPointFactory` contract?

Also, `DoubleEntryPoint` challenge is the only one which reverts when the `validateInstance` fails. It doesn't come from of my code, it was already there. Do you want me to fix that? (It's 2 lines)