### PR TITLE
text(MagicNum): improve level description

### DIFF
--- a/client/src/gamedata/en/descriptions/levels/magicnum.md
+++ b/client/src/gamedata/en/descriptions/levels/magicnum.md
@@ -3,9 +3,9 @@ To solve this level, you only need to provide the Ethernaut with a `Solver`, a c
 Easy right?
 Well... there's a catch.
 
-The solver's code needs to be really tiny. Really reaaaaaallly tiny. Like freakin' really really itty-bitty tiny: 10 opcodes at most.
+The solver's code needs to be really tiny. Really reaaaaaallly tiny. Like freakin' really really itty-bitty tiny: 10 bytes at most.
 
-Hint: Perhaps its time to leave the comfort of the Solidity compiler momentarily, and build this one by hand O_o. 
+Hint: Perhaps its time to leave the comfort of the Solidity compiler momentarily, and build this one by hand O_o.
 That's right: Raw EVM bytecode.
 
 Good luck!

--- a/client/src/gamedata/en/descriptions/levels/magicnum.md
+++ b/client/src/gamedata/en/descriptions/levels/magicnum.md
@@ -1,4 +1,4 @@
-To solve this level, you only need to provide the Ethernaut with a `Solver`, a contract that responds to `whatIsTheMeaningOfLife()` with the right number.
+To solve this level, you only need to provide the Ethernaut with a `Solver`, a contract that responds to `whatIsTheMeaningOfLife()` with the right 32 byte number.
 
 Easy right?
 Well... there's a catch.

--- a/client/src/gamedata/es/descriptions/levels/magicnum.md
+++ b/client/src/gamedata/es/descriptions/levels/magicnum.md
@@ -1,4 +1,4 @@
-Para resolver este nivel, solo necesitas proporcionar a Ethernaut un `Solver`, un contrato que responde a `whatIsTheMeaningOfLife()` con el número correcto.
+Para resolver este nivel, solo necesitas proporcionar a Ethernaut un `Solver`, un contrato que responde a `whatIsTheMeaningOfLife()` con el número correcto de 32 bytes.
 
 Fácil, ¿verdad?
 Bueno ... Hay una trampa.

--- a/client/src/gamedata/es/descriptions/levels/magicnum.md
+++ b/client/src/gamedata/es/descriptions/levels/magicnum.md
@@ -3,7 +3,7 @@ Para resolver este nivel, solo necesitas proporcionar a Ethernaut un `Solver`, u
 Fácil, ¿verdad?
 Bueno ... Hay una trampa.
 
-El código del `Solver` debe ser realmente pequeño. Realmeeeeeente diminuto. Jodidamente minúsculo: 10 opcodes como máximo.
+El código del `Solver` debe ser realmente pequeño. Realmeeeeeente diminuto. Jodidamente minúsculo: 10 bytes como máximo.
 
 Sugerencia: Quizás es hora de dejar la comodidad del compilador Solidity momentáneamente y construir este a mano O_o.
 Así es: puro bytecode EVM.

--- a/client/src/gamedata/fr/descriptions/levels/magicnum.md
+++ b/client/src/gamedata/fr/descriptions/levels/magicnum.md
@@ -1,4 +1,4 @@
-Pour résoudre ce niveau, il vous suffit de fournir à l'Ethernaut un `Solver`, un contrat qui répond à `whatIsTheMeaningOfLife()` (quel est le sens de la vie?) avec le bon numéro.
+Pour résoudre ce niveau, il vous suffit de fournir à l'Ethernaut un `Solver`, un contrat qui répond à `whatIsTheMeaningOfLife()` (quel est le sens de la vie?) avec le bon numéro de 32 octets.
 
 Facile, n'est ce pas?
 

--- a/client/src/gamedata/fr/descriptions/levels/magicnum.md
+++ b/client/src/gamedata/fr/descriptions/levels/magicnum.md
@@ -2,9 +2,9 @@ Pour résoudre ce niveau, il vous suffit de fournir à l'Ethernaut un `Solver`, 
 
 Facile, n'est ce pas?
 
-Eh bien...pas vraiment. 
+Eh bien...pas vraiment.
 
-Le code du `Solver` doit être vraiment petit. Vraiment tout petit. Comme vraiment vraiment minuscule : 10 opcodes au maximum.
+Le code du `Solver` doit être vraiment petit. Vraiment tout petit. Comme vraiment vraiment minuscule : 10 octets au maximum.
 
 Indice: Il est peut-être temps de quitter momentanément le confort du compilateur Solidity et de le construire à la main O_o.
 

--- a/client/src/gamedata/pt_br/descriptions/levels/magicnum.md
+++ b/client/src/gamedata/pt_br/descriptions/levels/magicnum.md
@@ -3,7 +3,7 @@ Para resolver este nível, você só precisa fornecer ao Ethernaut um `Solver`, 
 Fácil né?
 Então... Não é bem assim.
 
-O código do solucionador precisa ser muito pequeno. Realmente muuuuuuuuuuito pequenininho. Tipo muito muito minúsculo de pequeno: 10 opcodes no máximo.
+O código do solucionador precisa ser muito pequeno. Realmente muuuuuuuuuuito pequenininho. Tipo muito muito minúsculo de pequeno: 10 bytes no máximo.
 
 Dica: talvez seja hora de deixar momentaneamente o conforto do compilador Solidity e fazer isso manualmente O_o.
 Isso mesmo: bytecode EVM bruto.

--- a/client/src/gamedata/pt_br/descriptions/levels/magicnum.md
+++ b/client/src/gamedata/pt_br/descriptions/levels/magicnum.md
@@ -1,4 +1,4 @@
-Para resolver este nível, você só precisa fornecer ao Ethernaut um `Solver`, um contrato que responde `whatIsTheMeaningOfLife()` com o número certo.
+Para resolver este nível, você só precisa fornecer ao Ethernaut um `Solver`, um contrato que responde `whatIsTheMeaningOfLife()` com o número certo de 32 bytes.
 
 Fácil né?
 Então... Não é bem assim.

--- a/contracts/src/levels/MagicNumFactory.sol
+++ b/contracts/src/levels/MagicNumFactory.sol
@@ -25,7 +25,7 @@ contract MagicNumFactory is Level {
         bytes32 magic = solver.whatIsTheMeaningOfLife();
         if (magic != 0x000000000000000000000000000000000000000000000000000000000000002a) return false;
 
-        // Require the solver to have at most 10 opcodes.
+        // Require the solver to have at most 10 bytes.
         uint256 size;
         assembly {
             size := extcodesize(solver)


### PR DESCRIPTION
**Two changes were made to the Magic Number level description:**

1. `10 opcodes` was replaced with `10 bytes` because the level checks the code length in bytes, not the number of opcodes.
2. The length of the expected response (32 bytes) was added since it's not immediately clear how many bytes the contract should return.
