### PR TITLE
Missing gamedata

### DIFF
--- a/client/src/containers/Level.js
+++ b/client/src/containers/Level.js
@@ -29,7 +29,6 @@ class Level extends React.Component {
   }
 
   componentDidMount() {
-    this.props.loadGameData();
     this.props.activateLevel(this.props.params.address);
     document.addEventListener("mousedown", this.handleClickOutside);
   }

--- a/client/src/containers/Level.js
+++ b/client/src/containers/Level.js
@@ -29,6 +29,7 @@ class Level extends React.Component {
   }
 
   componentDidMount() {
+    this.props.loadGameData();
     this.props.activateLevel(this.props.params.address);
     document.addEventListener("mousedown", this.handleClickOutside);
   }
@@ -107,7 +108,6 @@ class Level extends React.Component {
   render() {
     const { level, levelCompleted } = this.props;
     const { submittedIntance } = this.state;
-
     var [levelData, selectedLevel] = getlevelsdata(this.props, "levelPage");
 
     if (!level) return null;

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -53,6 +53,7 @@ if (!window.ethereum) {
     } else {
       const accountConnectionWindow = document.querySelectorAll('.account-connection-window-bg');
       if (accountConnectionWindow[0]) accountConnectionWindow[0].style.display = 'block';
+      store.dispatch(actions.loadGamedata());
     }
   });
 }


### PR DESCRIPTION
When web3 provider is present but locked (Metamask not logged in for example), and loading directly a level URL without passing through the homepage, produced a 404 due to missing gamedata in the store. 

Forcing to load game data now.