### PR TITLE
Grammar and Spelling Fixes in Documentation

### DIFF
--- a/client/src/gamedata/en/descriptions/levels/doubleentrypoint_complete.md
+++ b/client/src/gamedata/en/descriptions/levels/doubleentrypoint_complete.md
@@ -4,7 +4,7 @@ This is the first experience you have with a [Forta bot](https://docs.forta.netw
 
 Forta comprises a decentralized network of independent node operators who scan all transactions and block-by-block state changes for outlier transactions and threats. When an issue is detected, node operators send alerts to subscribers of potential risks, which enables them to take action.
 
-The presented example is just for educational purpose since Forta bot is not modeled into smart contracts. In Forta, a bot is a code script to detect specific conditions or events, but when an alert is emitted it does not trigger automatic actions - at least not yet. In this level, the bot's alert effectively trigger a revert in the transaction, deviating from the intended Forta's bot design.
+The presented example is just for educational purposes since Forta bot is not modeled into smart contracts. In Forta, a bot is a code script to detect specific conditions or events, but when an alert is emitted it does not trigger automatic actions - at least not yet. In this level, the bot's alert effectively trigger a revert in the transaction, deviating from the intended Forta's bot design.
 
 Detection bots heavily depends on contract's final implementations and some might be upgradeable and break bot's integrations, but to mitigate that you can even create a specific bot to look for contract upgrades and react to it. Learn how to do it [here](https://docs.forta.network/en/latest/quickstart/).
 

--- a/client/src/gamedata/en/descriptions/levels/elevator_complete.md
+++ b/client/src/gamedata/en/descriptions/levels/elevator_complete.md
@@ -1,4 +1,4 @@
 You can use the `view` function modifier on an interface in order to prevent state modifications. The `pure` modifier also prevents functions from modifying the state.
 Make sure you read [Solidity's documentation](http://solidity.readthedocs.io/en/develop/contracts.html#view-functions) and learn its caveats.
 
-An alternative way to solve this level is to build a view function which returns different results depends on input data but don't modify state, e.g. `gasleft()`.
+An alternative way to solve this level is to build a view function which returns different results depending on input data but don't modify state, e.g. `gasleft()`.

--- a/client/src/gamedata/en/descriptions/levels/magicnum_complete.md
+++ b/client/src/gamedata/en/descriptions/levels/magicnum_complete.md
@@ -1,3 +1,3 @@
 Congratulations! If you solved this level, consider yourself a Master of the Universe. 
 
-Go ahead and pierce a random object in the room with your Magnum look. Now, try to move it from afar; Your telekinesis habilities might have just started working.
+Go ahead and pierce a random object in the room with your Magnum look. Now, try to move it from afar; Your telekinesis abilities might have just started working.


### PR DESCRIPTION

## Changes Made

### 1. `client/src/gamedata/en/descriptions/levels/magicnum_complete.md`:
- Changed "habilities" → "abilities"
- Reason: Corrected spelling error. "Habilities" is not a valid English word; "abilities" is the correct spelling.

### 2. `client/src/gamedata/en/descriptions/levels/elevator_complete.md`:
- Changed "depends" → "depending"
- Reason: Improved grammar. "Depending" is the correct form when describing a conditional relationship in this context.

### 3. `client/src/gamedata/en/descriptions/levels/doubleentrypoint_complete.md`:
- Changed "purpose" → "purposes"
- Reason: Grammatical agreement. Since we're referring to educational purposes in general, the plural form is more appropriate.

## Summary
These changes improve the readability and professional quality of the documentation by:
1. Correcting spelling errors
2. Improving grammatical consistency
3. Ensuring proper word usage in context

All changes are purely textual and do not affect any functional code.