### PR TITLE
fix(node): compatibility error when loading json files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # Private stuff
 client/.env
 contracts/.env
+contracts/build
 
 # Client
 client/build/

--- a/client/scripts/deploy_contracts.mjs
+++ b/client/scripts/deploy_contracts.mjs
@@ -6,11 +6,11 @@ import fs from "fs";
 import * as ethutil from "../src/utils/ethutil.js";
 import * as constants from "../src/constants.js";
 import HDWalletProvider from "@truffle/hdwallet-provider";
-import * as gamedata from "../src/gamedata/gamedata.json" assert { type: "json" };
-import * as EthernautABI from "../src/contracts/out/Ethernaut.sol/Ethernaut.json" assert { type: "json" };
-import * as ProxyAdminABI from "../src/contracts/out/ProxyAdmin.sol/ProxyAdmin.json" assert { type: "json" };
-import * as ImplementationABI from "../src/contracts/out/Statistics.sol/Statistics.json" assert { type: "json" };
-import * as ProxyStatsABI from "../src/contracts/out/ProxyStats.sol/ProxyStats.json" assert { type: "json" };
+import * as gamedata from "../src/gamedata/gamedata.json" with { type: "json" };
+import * as EthernautABI from "../src/contracts/out/Ethernaut.sol/Ethernaut.json" with { type: "json" };
+import * as ProxyAdminABI from "../src/contracts/out/ProxyAdmin.sol/ProxyAdmin.json" with { type: "json" };
+import * as ImplementationABI from "../src/contracts/out/Statistics.sol/Statistics.json" with { type: "json" };
+import * as ProxyStatsABI from "../src/contracts/out/ProxyStats.sol/ProxyStats.json" with { type: "json" };
 
 let web3;
 let ethernaut;


### PR DESCRIPTION
Thanks for your great work!

This PR has 2 changes:

1. adding `contracts/out` directory to the .gitignore

2. fixing a node compatibility error as elaborated below:

When I `yarn deploy:contracts`, I faced the following error:

```
file:///~/ethernaut/client/scripts/deploy_contracts.mjs:9
import * as gamedata from "../src/gamedata/gamedata.json" assert { type: "json" };
                                                          ^^^^^^

SyntaxError: Unexpected identifier 'assert'
    at compileSourceTextModule (node:internal/modules/esm/utils:340:16)
    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:102:18)
    at #translate (node:internal/modules/esm/loader:433:12)
    at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:480:27)
    at async ModuleJob._link (node:internal/modules/esm/module_job:112:19)

Node.js v22.11.0
Linux
```

[This answer](https://stackoverflow.com/a/78876692) on Stack Overflow explains _the Why_ behind the error.