### PR TITLE
Fix: Consistent use of double quotes

### DIFF
--- a/client/src/components/common/Markdown.js
+++ b/client/src/components/common/Markdown.js
@@ -28,7 +28,7 @@ class Markdown extends React.Component {
 
   async loadContents(target) {
     if(!this._isMounted) return
-    let targetText = typeof target == 'string' ? target : target.default;
+    let targetText = typeof target == "string" ? target : target.default;
     if(this.state.target === targetText) return
     try {
       const text = /md?$/.test(targetText) ?  await loadText(targetText) : targetText;

--- a/client/src/components/leaderboard/Headers.js
+++ b/client/src/components/leaderboard/Headers.js
@@ -1,11 +1,11 @@
 function Headers() { 
     return (
-        <div className='leaderboard-tile'>
+        <div className="leaderboard-tile">
             <div className="leaderboard-rank leaderboard-header">Rank</div>
             <div className="leaderboard-player leaderboard-header">Player</div>
             <div  className="leaderboard-levels-solved leaderboard-header">Levels solved</div>
             <div className="leaderboard-score leaderboard-header">Score</div>
-            <div className='leaderboard-alias-edit'></div>
+            <div className="leaderboard-alias-edit"></div>
         </div>
     )
 }

--- a/client/src/components/leaderboard/Hubspot.js
+++ b/client/src/components/leaderboard/Hubspot.js
@@ -95,13 +95,13 @@ class HubspotForm extends React.Component{
     const element = document.createElement('div')
     element.innerHTML = "Thanks for submitting the form."
     element.style.color = textColor
-    element.style.position = 'relative'
-    element.style.fontSize = '17px'
-    outerElement.insertAdjacentElement('afterbegin', element)
+    element.style.position = "relative"
+    element.style.fontSize = "17px"
+    outerElement.insertAdjacentElement("afterbegin", element)
 
     // change the height of modal
-    const modal = document.querySelector('.leaderboard-modal-body')
-    modal.style.height = '150px'
+    const modal = document.querySelector(".leaderboard-modal-body")
+    modal.style.height = "150px"
   }
 
   render() {


### PR DESCRIPTION
## Description
Change all single-quoted strings to double quotes for consistency in other not to cause improper rendering in the future.

## Changes
Replaced all the single quotes used on this files below with double quotes for consistent code review.

Markdown.js
Headers.js
Hubspot.js