### PR TITLE
Fix Switch level deployment failure - Issue #837

### DIFF
--- a/client/src/gamedata/gamedata.json
+++ b/client/src/gamedata/gamedata.json
@@ -459,7 +459,7 @@
       "deployParams": [],
       "deployFunds": 0,
       "deployId": "29",
-      "instanceGas": 250000,
+      "instanceGas": 1000000,
       "author": "AgeManning"
     },
     {

--- a/client/src/utils/ethutil.js
+++ b/client/src/utils/ethutil.js
@@ -171,18 +171,43 @@ export const verifySignature = (json) => {
 
 export const signMessageWithMetamask = (addr, message, callback) => {
   const msg = ethjs.bufferToHex(new Buffer(message, 'utf8'));
-  web3.currentProvider.sendAsync({
-    method: 'personal_sign',
-    params: [msg, addr],
-    addr
-  }, function (err, res) {
-    callback({
-      address: addr,
-      msg: message,
-      sig: res.result,
-      version: '2'
+  
+  // Use modern ethereum.request() method instead of deprecated sendAsync
+  if (window.ethereum && window.ethereum.request) {
+    window.ethereum.request({
+      method: 'personal_sign',
+      params: [msg, addr]
+    }).then(res => {
+      callback({
+        address: addr,
+        msg: message,
+        sig: res,
+        version: '2'
+      });
+    }).catch(err => {
+      console.error('MetaMask signing error:', err);
+      callback(null);
     });
-  });
+  } else {
+    // Fallback to sendAsync for older providers
+    web3.currentProvider.sendAsync({
+      method: 'personal_sign',
+      params: [msg, addr],
+      addr
+    }, function (err, res) {
+      if (err) {
+        console.error('Fallback signing error:', err);
+        callback(null);
+      } else {
+        callback({
+          address: addr,
+          msg: message,
+          sig: res.result,
+          version: '2'
+        });
+      }
+    });
+  }
 }
 
 export const logger = (req, res, next, end) => {


### PR DESCRIPTION
## Bug Fix Summary
- Fixed Switch level deployment failures caused by insufficient gas limits
- Updated deprecated MetaMask `sendAsync` to modern `ethereum.request()`
- Added proper error handling to prevent frontend crashes
- Increased instanceGas from 250,000 to 1,000,000 for Switch level

## Issue Reference
Fixes #837 where Switch level instance deployment fails with transaction reverts and frontend crashes.

## Changes Made
- client/src/utils/ethutil.js: 
Updated MetaMask integration from deprecated `sendAsync` to modern `ethereum.request()` with proper error handling
- client/src/gamedata/gamedata.json: 
Increased Switch level instanceGas from 250,000 to 1,000,000