### PR TITLE
fix: increase instanceGas for Switch level to prevent out-of-gas error

### DIFF
--- a/client/src/gamedata/gamedata.json
+++ b/client/src/gamedata/gamedata.json
@@ -459,7 +459,7 @@
       "deployParams": [],
       "deployFunds": 0,
       "deployId": "29",
-      "instanceGas": 250000,
+      "instanceGas": 300000,
       "author": "AgeManning"
     },
     {


### PR DESCRIPTION
The current instanceGas buffer for the Switch level is insufficient, leading to consistent Out of Gas errors during instantiation on the Sepolia network.

Observed Behavior:
- Current setting: instanceGas: 250000
- Actual gas consumed: ~469,800 units (on Sepolia)
- Result: Transactions fail at nearly 100% gas usage with the default limit (~450k).

Changes:
- I have increased the instanceGas for the Switch level from 250,000 to 300,000.