### PR TITLE
fix: correct vm.label for user2 in Ethernaut.t.sol

### DIFF
--- a/contracts/test/Ethernaut.t.sol
+++ b/contracts/test/Ethernaut.t.sol
@@ -36,7 +36,7 @@ contract TestEthernaut is Test {
         vm.label(user, "User 1");
 
         user2 = users[1];
-        vm.label(user, "User 2");
+        vm.label(user2, "User 2");
 
         owner = users[2];
         vm.label(owner, "Owner");


### PR DESCRIPTION
## Summary
- `setUp()` in `contracts/test/Ethernaut.t.sol` was labeling `user` (address 0) as `"User 2"` instead of labeling `user2` (address 1), making forge trace output misleading (two addresses both showing as related to "User 1"/mislabeled).

## Fix
- Changed `vm.label(user, "User 2")` to `vm.label(user2, "User 2")`.

## Test plan
- [x] `forge test --match-contract TestEthernaut -vv` — all 7 tests pass